### PR TITLE
Speed up hot reload using Dom patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ Run `bin/run` (or <kbd>Ctrl+Shift+B</kbd> in VSCode). This runs the clock exampl
   - [x] client to server reconnect (on ghcid reload, or accidental client disconnect)
     - [x] or, investigate https://hackage.haskell.org/package/ghci-websockets
 - [x] Multi-websocket-client support
-- [ ] Refactor Server.hs
 - [ ] Static site generation mode
 - [ ] add common examples,
   - [x] filesystem watcher
   - [ ] docs site for self (w/ sidebar and possibly even search)
 
 pre-announce,
-- [ ] plan features / messaging, re: hakyll
-  - Safer and simpler routes system
-  - Template system?
 - [ ] CLI UX (opts, logging, etc.)
-- [ ] documentation ([howto](https://documentation.divio.com/))
+- [ ] How to serve non-generated files (css, img, etc.)
 - [ ] Publish Data.LVar to Hackage
+- [ ] documentation ([howto](https://documentation.divio.com/))
 
 doc notes,
 - use async:race to avoid ghcid ghosts
 - at most one ws client supported right now
 - tailwind + blaze-html layout (BlazeWind?) for no-frills getting started
 - [dealing with errors](https://github.com/srid/memoir/issues/1)
+- messaging re: hakyll 
+  - safer/ simpler routes system
+  - bring your own templates / DSL

--- a/src/Ema/Server.hs
+++ b/src/Ema/Server.hs
@@ -57,7 +57,7 @@ runServerWithWebSocketHotReload port model render = do
                 Left newHtml -> do
                   -- The page the user is currently viewing has changed. Send
                   -- the new HTML to them.
-                  WS.sendTextData conn $ routeHtml newHtml watchingRoute
+                  WS.sendTextData conn $ render newHtml watchingRoute
                   log $ "[Watch]: ~~> " <> show watchingRoute
                   loop
                 Right nextRoute -> do
@@ -67,7 +67,7 @@ runServerWithWebSocketHotReload port model render = do
                   -- request immediately following this).
                   log $ "[Switch]: <~~ " <> show nextRoute
                   html <- LVar.get model
-                  WS.sendTextData conn $ routeHtml html nextRoute
+                  WS.sendTextData conn $ render html nextRoute
                   log $ "[Switch]: ~~> " <> show nextRoute
                   loop
         try loop >>= \case
@@ -81,12 +81,12 @@ runServerWithWebSocketHotReload port model render = do
           pure (H.status404, "No route")
         Just r -> do
           val <- LVar.get model
-          pure (H.status200, routeHtml val r)
+          pure (H.status200, renderWithEmaShims val r)
       f $ Wai.responseLBS status [(H.hContentType, "text/html")] v
     routeFromPathInfo =
       fromSlug . fmap (fromString . toString)
-    routeHtml :: model -> route -> LByteString
-    routeHtml m r = do
+    renderWithEmaShims :: model -> route -> LByteString
+    renderWithEmaShims m r = do
       render m r <> emaStatusHtml <> wsClientShim
 
 -- | Return the equivalent of WAI's @pathInfo@, from the raw path string


### PR DESCRIPTION
Thanks to https://github.com/patrick-steele-idem/morphdom - we can now update only what's changed, instead of replacing and re-rendering the entire HTML.

Now hot reload is *too fast* that we might want to slow it down with animations!