### PR TITLE
URI encoding for slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `Ema.Slug`
   - Add `Ord` instance to `Slug`
   - Unicode normalize slugs using NFC
+  - Add `decodeSlug` and `encodeSlug`
 - Add default implementation based on Enum for `staticRoute`
 - Helpers
   - Helpers.FileSystem

--- a/ema.cabal
+++ b/ema.cabal
@@ -55,6 +55,7 @@ library
     , text
     , unicode-transforms
     , unliftio
+    , uri-encode
     , wai
     , wai-middleware-static
     , wai-websockets

--- a/src/Ema/Route.hs
+++ b/src/Ema/Route.hs
@@ -5,13 +5,15 @@ module Ema.Route
   ( routeUrl,
     routeFile,
     Slug (unSlug),
+    decodeSlug,
+    encodeSlug,
     UrlStrategy (..),
   )
 where
 
 import Data.Default (def)
 import Ema.Class
-import Ema.Route.Slug (Slug (unSlug))
+import Ema.Route.Slug (Slug (unSlug), decodeSlug, encodeSlug)
 import Ema.Route.UrlStrategy
   ( UrlStrategy (..),
     slugFileWithStrategy,

--- a/src/Ema/Route/Slug.hs
+++ b/src/Ema/Route/Slug.hs
@@ -4,10 +4,22 @@ module Ema.Route.Slug where
 
 import qualified Data.Text as T
 import qualified Data.Text.Normalize as UT
+import qualified Network.URI.Encode as UE
 
 -- | An URL path is made of multiple slugs, separated by '/'
 newtype Slug = Slug {unSlug :: Text}
   deriving (Eq, Show, Ord)
+
+-- | Decode an URL component into a Slug
+--
+-- Replace '%20' etc with appropriate text.
+decodeSlug :: Text -> Slug
+decodeSlug =
+  fromString . UE.decode . toString
+
+encodeSlug :: Slug -> Text
+encodeSlug =
+  UE.encodeText . unSlug
 
 instance IsString Slug where
   fromString :: HasCallStack => String -> Slug

--- a/src/Ema/Route/Slug.hs
+++ b/src/Ema/Route/Slug.hs
@@ -10,13 +10,12 @@ import qualified Network.URI.Encode as UE
 newtype Slug = Slug {unSlug :: Text}
   deriving (Eq, Show, Ord)
 
--- | Decode an URL component into a Slug
---
--- Replace '%20' etc with appropriate text.
+-- | Decode an URL component into a `Slug` using `Network.URI.Encode`
 decodeSlug :: Text -> Slug
 decodeSlug =
   fromString . UE.decode . toString
 
+-- | Encode a `Slug` into an URL component using `Network.URI.Encode`
 encodeSlug :: Slug -> Text
 encodeSlug =
   UE.encodeText . unSlug

--- a/src/Ema/Server.hs
+++ b/src/Ema/Server.hs
@@ -10,6 +10,7 @@ import Data.LVar (LVar)
 import qualified Data.LVar as LVar
 import qualified Data.Text as T
 import Ema.Class (Ema (decodeRoute, staticAssets), MonadEma)
+import qualified Ema.Route.Slug as Slug
 import GHC.IO.Unsafe (unsafePerformIO)
 import NeatInterpolation (text)
 import qualified Network.HTTP.Types as H
@@ -126,7 +127,7 @@ runServerWithWebSocketHotReload port model render = do
                 <> show @Text err
                 <> "</pre><p>Once you fix your code this page will automatically update.</body>"
     routeFromPathInfo =
-      decodeRoute @model . fmap (fromString . toString)
+      decodeRoute @model . fmap Slug.decodeSlug
     -- TODO: It would be good have this also get us the stack trace.
     unsafeCatch :: Exception e => a -> (e -> a) -> a
     unsafeCatch x f = unsafePerformIO $ catch (seq x $ pure x) (pure . f)


### PR DESCRIPTION
Allows URLs with whitespace and special characters. Eg: `/pages/about this site`.