### PR TITLE
Wikilink support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@
   - Helpers.Tailwind
     - add overflow-y-scroll to body
     - Add twind shim *before* application's head
-  - Helpers.Markdown
+  - Helpers.Markdown (to be moved to Hackage eventually)
     - add helpers to parse markdown; `parseMarkdownWithFrontMatter` and `parseMarkdown`
+    - add wikilink helpers
   - Add `Ema.Helper.PathTree`
 - Examples
   - Remove Ex03_Documentation.hs (moved to separate repo, `ema-docs`)

--- a/ema.cabal
+++ b/ema.cabal
@@ -73,6 +73,7 @@ library
       , HsYAML
       , megaparsec
       , pandoc-types
+      , parsec
       , parser-combinators
 
     if flag(with-examples)

--- a/src/Ema/Helper/Markdown.hs
+++ b/src/Ema/Helper/Markdown.hs
@@ -37,9 +37,13 @@ import qualified Text.Parsec as P
 
 -- | Parse a Markdown file using commonmark-hs with all extensions enabled
 parseMarkdownWithFrontMatter ::
-  forall meta.
-  (Y.FromYAML meta) =>
-  (forall m il bl. SyntaxSpec' m il bl => CM.SyntaxSpec m il bl) ->
+  forall meta m il bl.
+  ( Y.FromYAML meta,
+    m ~ Either CM.ParseError,
+    bl ~ CP.Cm () B.Blocks,
+    il ~ CP.Cm () B.Inlines
+  ) =>
+  CM.SyntaxSpec m il bl ->
   -- | Path to file associated with this Markdown
   FilePath ->
   -- | Markdown text to parse
@@ -167,6 +171,9 @@ instance
   HasWikilinks (CM.WithSourceMap il)
   where
   wikilink typ url il = (wikilink typ url <$> il) <* CM.addName "wikilink"
+
+instance HasWikilinks (CP.Cm b B.Inlines) where
+  wikilink typ t il = CP.Cm $ B.link t (show typ) $ CP.unCm il
 
 -- | Like `Commonmark.Extensions.Wikilinks.wikilinksSpec` but Zettelkasten-friendly.
 --

--- a/src/Ema/Helper/Markdown.hs
+++ b/src/Ema/Helper/Markdown.hs
@@ -142,7 +142,7 @@ plainify = W.query $ \case
   -- `Inline` which `W.query` will traverse again.
   _ -> ""
 
--- TODO: Probably not a good idea to force users to deal with folgezettels.
+-- TODO: Probably not a good idea to force users to deal with folgezettels?
 data WikiLinkType
   = -- | [[Foo]]
     WikiLinkNormal
@@ -179,10 +179,11 @@ wikiLinkSpec =
           ]
     wikiLinkP :: Monad m => P.ParsecT [CM.Tok] s m Text
     wikiLinkP = do
-      void $ CT.satisfyWord (== "[[")
-      s <- fmap CM.untokenize $ some $ CT.noneOfToks [CM.Symbol ']', CM.Symbol '[', CM.LineEnd]
-      void $ CT.satisfyWord (== "]]")
-      pure s
+      let open = '['
+          close = ']'
+          parenP = replicateM_ 2 . CT.symbol
+          innerP = fmap CM.untokenize $ some $ CT.noneOfToks [CM.Symbol open, CM.Symbol close, CM.LineEnd]
+      parenP '[' *> innerP <* parenP ']'
     cmAutoLink :: CM.IsInline a => WikiLinkType -> Text -> a
     cmAutoLink typ wikiLinkText =
       CM.link url title $ CM.str wikiLinkText

--- a/src/Ema/Helper/Markdown.hs
+++ b/src/Ema/Helper/Markdown.hs
@@ -183,7 +183,7 @@ wikilinksSpec =
     pWikilink = do
       replicateM_ 2 $ CT.symbol '['
       P.notFollowedBy (CT.symbol '[')
-      title <-
+      url <-
         CM.untokenize
           <$> many
             ( CT.satisfyTok
@@ -191,8 +191,8 @@ wikilinksSpec =
                     not (CT.hasType (CM.Symbol '|') t || CT.hasType (CM.Symbol ']') t)
                 )
             )
-      url <-
-        M.option title $
+      title <-
+        M.option url $
           CM.untokenize
             <$> ( CT.symbol '|'
                     *> many (CT.satisfyTok (not . CT.hasType (CM.Symbol ']')))

--- a/src/Ema/Helper/Markdown.hs
+++ b/src/Ema/Helper/Markdown.hs
@@ -177,9 +177,11 @@ wikiLinkSpec =
       void $ M.count n $ symbol ']'
       pure s
     cmAutoLink :: CM.IsInline a => WikiLinkType -> Text -> a
-    cmAutoLink conn url =
-      CM.link url title $ CM.str url
+    cmAutoLink typ wikiLinkText =
+      CM.link url title $ CM.str wikiLinkText
       where
         -- Store connetion type in 'title' attribute for latter lookup.
         -- TODO: Put it in attrs instead; requires PR to commonmark
-        title = show conn
+        title = show typ
+        -- If [[Foo]], use url Foo.md
+        url = wikiLinkText <> ".md"


### PR DESCRIPTION
Temporary staging in Ema, until these Markdown utilities are moved to their own Haskell library on hackage.