### PR TITLE
.cabal: drop some unused deps

### DIFF
--- a/ema.cabal
+++ b/ema.cabal
@@ -39,7 +39,6 @@ library
     , async
     , base                   >=4.13.0.0 && <=4.17.0.0
     , containers
-    , data-default
     , directory
     , filepath
     , filepattern
@@ -50,8 +49,6 @@ library
     , neat-interpolation
     , optparse-applicative
     , relude                 >=0.7      && <1.0
-    , safe-exceptions
-    , stm
     , text
     , unicode-transforms
     , unionmount
@@ -70,7 +67,6 @@ library
       , commonmark
       , commonmark-extensions
       , commonmark-pandoc
-      , fsnotify               ^>=0.3
       , megaparsec
       , pandoc-types
       , parsec
@@ -129,3 +125,5 @@ library
 
   hs-source-dirs:     src
   default-language:   Haskell2010
+  if impl(ghc >= 8.10)
+    ghc-options:       -Wunused-packages


### PR DESCRIPTION
AFAICT from `ghc-8.10 -Wunused-packages`:
data-default, safe-exceptions, stm, fsnotify
are not directly required as build-depends currently.