### PR TITLE
Allow user-defined Javascript to run after hot reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Tailwind.layoutWith`: don't hardcode `<body>` attrs
 - `runEma` and friends: 
   - return the monadic's action's return value or generated files (dependent type)
+- Provide a way to run any Javascript on reload by defining the `emaHotReloadHook()` function.
 
 ## 0.2.0.0 -- 2021-11-21
 

--- a/docs/concepts/hot-reload.md
+++ b/docs/concepts/hot-reload.md
@@ -28,3 +28,9 @@ For anything outside of the Haskell code, your code becomes responsible for moni
 ## Handling errors
 
 If your code throws a Haskell exception, they will be gracefully handled and displayed in the browser, allowing you to recover without breaking hot-reload flow.
+
+## Calling Javascript after hot reload events
+
+If you need to invoke some javascript upon page reloads, define a javascript function named `emaHotReloadHook`. It will be called after patching the DOM is complete.
+
+This is useful for content that relies on further Javascript processing to be displayed properly, such as mathematics via MathJax.

--- a/src/Ema/Server.hs
+++ b/src/Ema/Server.hs
@@ -339,6 +339,9 @@ wsClientShim =
             } else {
               console.log("ema: ✍ Patching DOM");
               setHtml(document.documentElement, evt.data);
+              if ("emaHotReloadHook" in window) {
+                emaHotReloadHook();
+              }
               if (routeVisible != document.location.pathname) {
                 // This is a new route switch; scroll up.
                 window.scrollTo({ top: 0});


### PR DESCRIPTION
This patch allows the user to specify the javascript they want to run every time the page finishes updating the content with a hot-reload.

They do so by defining the function named `emaHotReloadHook()` in their custom `<head>`.

## Motivation 

My neuron/emanote notebook relies heavily on MathJax support to render mathematics. Upon migrating to Emanote, I needed a way to instruct MathJax to redraw it. MathJax provides instructions for handling such a case [here](https://docs.mathjax.org/en/latest/advanced/typeset.html#mathjax-in-dynamic-content).

In principle the way Ema replaces `<script>` tags might have taken care of this case. However it seemed not to work, as the initial hot reload event that arrives right after opening the page replaced the rendered math (visible only for a flash) with the unprocessed source text. 

In addition, there are known problems pertaining to multiple concurrent math renders. Since the first hot-reload event arrives very quickly after the page loads, it is important to have direct control over the JS invoked upon reload events to deal gracefully with this.

## Alternatives considered

- I initially suggested that Ema should accept configuration (i.e. in Haskell) that contains the desired javascript directly. In many ways I find such a direct and explicit approach favorable, however it would seemingly require rather significant changes to the Haskell type signatures to accommodate (there is no place to simple add a field or similar). Given that this is a minor feature, and given the limited valuable time of the contributors for this open source project, the more simple solution implemented in this patch may be the better tradeoff.

- We also considered indicating through some special attributes that a particular `<script>` tag was to be run on hot reload. However these approaches also had problems
  - If the script has type `text/javascript` then they are always run when the page first loads in addition to after the reload events, which defeats the purpose of the feature. For my use-case it is critical to have code that runs *only* after reloads to properly deal with race conditions involving the initial render.
  - If the script has some other type, like `text/ema-hot-reload` then, as desired, the script does not run on page load. But we'd need to use something like `eval` to run it. `eval` is generally considered undesirable both from a security perspective, as well as for potentially interfering with browser Javascript optimizations. Overall this approach also has more complexity compared to the simple solution.