### PR TITLE
Determine `MotleyRouteSubRoutes` generically

### DIFF
--- a/ema.cabal
+++ b/ema.cabal
@@ -56,6 +56,7 @@ library
     , optparse-applicative
     , relude                  >=1.0
     , sop-core
+    , symbols
     , text
     , unliftio
     , url-slug
@@ -142,6 +143,7 @@ library
     Ema.Route.Url
     Ema.Server
     Ema.Site
+    GHC.TypeLits.Extra.Symbol
     Optics.CtxPrism
 
   if flag(with-examples)

--- a/src/Ema/Multi/Generic/Example.hs
+++ b/src/Ema/Multi/Generic/Example.hs
@@ -28,7 +28,7 @@ type M = (Int, Int, String)
 
 data R = R_Index | R_Foo | R_Bar NumRoute | R_Bar2 NumRoute
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (SOP.Generic)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo, MotleyRoute)
   deriving (IsRoute) via (WithModel R M) -- This only works if MotleyModelType R ~ M
 
 data NumRoute = NumRoute
@@ -44,6 +44,7 @@ instance IsRoute NumRoute where
   allRoutes _ = [NumRoute]
 
 -- TODO: We want to derive MotleyRoute generically.
+{-
 instance MotleyRoute R where
   type
     MotleyRouteSubRoutes R =
@@ -52,6 +53,7 @@ instance MotleyRoute R where
        , PrefixedRoute "bar" NumRoute
        , PrefixedRoute "bar2" NumRoute
        ]
+-}
 
 -- TODO: In many simple cases (such as single model cases) this can be derived
 -- generically. But allow the user to define this manually if need be. Also cf.
@@ -77,7 +79,7 @@ type TM = (M, String)
 
 data TR = TR_Index | TR_Inner R
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (SOP.Generic)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
   deriving (IsRoute) via (WithModel TR TM) -- This only works if MotleyModelType R ~ M
 
 instance MotleyRoute TR where
@@ -121,12 +123,12 @@ type M2 = (Int, String)
 
 data R2 = R2_Index | R2_Foo | R2_Bar BarRoute | R2_Bar2 BarRoute
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (SOP.Generic)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
   deriving (IsRoute, MotleyModel) via (WithConstModel R2 M2)
 
 data BarRoute = BarRoute
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (SOP.Generic)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
   deriving (IsRoute, MotleyModel) via (WithConstModel BarRoute M2)
 
 instance MotleyRoute BarRoute where

--- a/src/Ema/Multi/Generic/Example.hs
+++ b/src/Ema/Multi/Generic/Example.hs
@@ -31,6 +31,19 @@ data R = R_Index | R_Foo | R_Bar NumRoute | R_Bar2 NumRoute
   deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo, MotleyRoute)
   deriving (IsRoute) via (WithModel R M) -- This only works if MotleyModelType R ~ M
 
+-- ^ MotleyRoute instance generates:
+
+{-
+instance MotleyRoute R where
+  type
+    MotleyRouteSubRoutes R =
+      '[ SingletonRoute "index.html"
+       , SingletonRoute "foo.html"
+       , PrefixedRoute "bar" NumRoute
+       , PrefixedRoute "bar2" NumRoute
+       ]
+-}
+
 data NumRoute = NumRoute
   deriving stock (Show, Eq)
 
@@ -42,18 +55,6 @@ instance IsRoute NumRoute where
           guard $ s == fp
           pure NumRoute
   allRoutes _ = [NumRoute]
-
--- TODO: We want to derive MotleyRoute generically.
-{-
-instance MotleyRoute R where
-  type
-    MotleyRouteSubRoutes R =
-      '[ SingletonRoute "index.html"
-       , SingletonRoute "foo.html"
-       , PrefixedRoute "bar" NumRoute
-       , PrefixedRoute "bar2" NumRoute
-       ]
--}
 
 -- TODO: In many simple cases (such as single model cases) this can be derived
 -- generically. But allow the user to define this manually if need be. Also cf.
@@ -79,11 +80,8 @@ type TM = (M, String)
 
 data TR = TR_Index | TR_Inner R
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo, MotleyRoute)
   deriving (IsRoute) via (WithModel TR TM) -- This only works if MotleyModelType R ~ M
-
-instance MotleyRoute TR where
-  type MotleyRouteSubRoutes TR = '[SingletonRoute "index.html", PrefixedRoute "inner" R]
 
 instance MotleyModel TR where
   type MotleyModelType TR = TM
@@ -123,19 +121,13 @@ type M2 = (Int, String)
 
 data R2 = R2_Index | R2_Foo | R2_Bar BarRoute | R2_Bar2 BarRoute
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo, MotleyRoute)
   deriving (IsRoute, MotleyModel) via (WithConstModel R2 M2)
 
 data BarRoute = BarRoute
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo, MotleyRoute)
   deriving (IsRoute, MotleyModel) via (WithConstModel BarRoute M2)
-
-instance MotleyRoute BarRoute where
-  type MotleyRouteSubRoutes BarRoute = '[SingletonRoute "index.html"]
-
-instance MotleyRoute R2 where
-  type MotleyRouteSubRoutes R2 = '[SingletonRoute "index.html", SingletonRoute "foo", PrefixedRoute "bar" BarRoute, PrefixedRoute "bar2" BarRoute]
 
 instance EmaSite R2 where
   siteInput _ _ () = pure $ pure (21, "inner")

--- a/src/Ema/Multi/Generic/Motley.hs
+++ b/src/Ema/Multi/Generic/Motley.hs
@@ -93,10 +93,11 @@ type family
   where
   Constructor2RoutePath name constr suffix =
     AppendSymbol
-      ( ToLower
+      ( -- Instead of ToLower we want Camel2Kebab here, ideally.
+        -- So that `Foo_BarQux` encodes to bar-qux instead of barqux.
+        ToLower
           ( StripPrefix
               (AppendSymbol name "_")
-              -- TODO: Slugify this
               constr
           )
       )

--- a/src/Ema/Multi/Generic/Motley.hs
+++ b/src/Ema/Multi/Generic/Motley.hs
@@ -78,7 +78,7 @@ type family GMotleyRouteSubRoutes (name :: SOPM.DatatypeName) (constrs :: [SOPM.
   GMotleyRouteSubRoutes name (c ': cs) (x ': xs) = PrefixedRoute (Constructor2RoutePath name c) x ': GMotleyRouteSubRoutes name cs xs
 
 type family Constructor2RoutePath (name :: SOPM.DatatypeName) (constr :: SOPM.ConstructorName) :: Symbol where
--- TODO: replace 'constr' with "${name}_${toLower constr}". This requires heavy type-level symbol processing.
+-- TODO: replace 'constr' with "${toLower ${stripPrefix '${name}_' constr}}". This requires heavy type-level symbol processing.
   Constructor2RoutePath name constr = constr
 
 class MotleyRoute r => MotleyModel r where

--- a/src/Ema/Multi/Generic/RGeneric.hs
+++ b/src/Ema/Multi/Generic/RGeneric.hs
@@ -42,15 +42,6 @@ instance (RGeneric' xss, RouteNP xs) => RGeneric' (xs ': xss) where
     Z (I t) -> Z $ toRouteNP t
     S rest -> S $ rto' @xss rest
 
-{- | Like `DatatypeInfo` but pertaining to Route types only.
-
- The main difference is that it uses a `Maybe` instead of a `[]` to represent
- ADT constructors in line with `RouteNP`.
--}
-data RDatatypeInfo
-  = RADT SOPM.ModuleName SOPM.DatatypeName (Maybe SOPM.ConstructorInfo)
-  | RNewtype SOPM.ModuleName SOPM.DatatypeName SOPM.ConstructorInfo
-
 type family RDatatypeName' (info :: SOPM.DatatypeInfo) :: SOPM.DatatypeName where
   RDatatypeName' ( 'SOPM.ADT _ name _ _) =
     name

--- a/src/Ema/Multi/Generic/RGeneric.hs
+++ b/src/Ema/Multi/Generic/RGeneric.hs
@@ -5,16 +5,21 @@ module Ema.Multi.Generic.RGeneric where
 
 import GHC.TypeLits (ErrorMessage (Text), TypeError)
 import Generics.SOP
+import Generics.SOP.Type.Metadata qualified as SOPM
 import Prelude hiding (All, Generic)
 
 -- | Like `Generic` but for Route types only.
-class Generic r => RGeneric r where
+class (Generic r, HasDatatypeInfo r) => RGeneric r where
   type RCode r :: [Type]
+  type RDatatypeName r :: SOPM.DatatypeName
+  type RConstructorNames r :: [SOPM.ConstructorName]
   rfrom :: r -> NS I (RCode r)
   rto :: NS I (RCode r) -> r
 
-instance (Generic r, RGeneric' (Code r), All RouteNP (Code r)) => RGeneric r where
+instance (Generic r, HasDatatypeInfo r, RGeneric' (Code r), All RouteNP (Code r)) => RGeneric r where
   type RCode r = RCode' (Code r)
+  type RDatatypeName r = RDatatypeName' (DatatypeInfoOf r)
+  type RConstructorNames r = RConstructorNames' (DatatypeInfoOf r)
   rfrom = rfrom' @(Code r) . unSOP . from
   rto = to . SOP . rto' @(Code r)
 
@@ -36,6 +41,39 @@ instance (RGeneric' xss, RouteNP xs) => RGeneric' (xs ': xss) where
   rto' = \case
     Z (I t) -> Z $ toRouteNP t
     S rest -> S $ rto' @xss rest
+
+{- | Like `DatatypeInfo` but pertaining to Route types only.
+
+ The main difference is that it uses a `Maybe` instead of a `[]` to represent
+ ADT constructors in line with `RouteNP`.
+-}
+data RDatatypeInfo
+  = RADT SOPM.ModuleName SOPM.DatatypeName (Maybe SOPM.ConstructorInfo)
+  | RNewtype SOPM.ModuleName SOPM.DatatypeName SOPM.ConstructorInfo
+
+type family RDatatypeName' (info :: SOPM.DatatypeInfo) :: SOPM.DatatypeName where
+  RDatatypeName' ( 'SOPM.ADT _ name _ _) =
+    name
+  RDatatypeName' ( 'SOPM.Newtype _ name _) =
+    name
+
+type family RConstructorNames' (info :: SOPM.DatatypeInfo) :: [SOPM.ConstructorName] where
+  RConstructorNames' ( 'SOPM.ADT _ _ constrs _) =
+    GetConstructorNames constrs
+  RConstructorNames' ( 'SOPM.Newtype _ _ constr) =
+    '[GetConstructorName constr]
+
+type family GetConstructorName (info :: SOPM.ConstructorInfo) :: SOPM.ConstructorName where
+  GetConstructorName ( 'SOPM.Constructor name) =
+    name
+  GetConstructorName ( 'SOPM.Infix name _ _) =
+    name
+  GetConstructorName ( 'SOPM.Record name _) =
+    name
+
+type family GetConstructorNames (infos :: [SOPM.ConstructorInfo]) :: [SOPM.ConstructorName] where
+  GetConstructorNames '[] = '[]
+  GetConstructorNames (x ': xs) = GetConstructorName x ': GetConstructorNames xs
 
 {- | Class of `NP` that can be used in a route tyupe.
 

--- a/src/GHC/TypeLits/Extra/Symbol.hs
+++ b/src/GHC/TypeLits/Extra/Symbol.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+-- TODO: Upstream this to symbols package
+module GHC.TypeLits.Extra.Symbol where
+
+import Data.Symbol.Ascii
+import GHC.TypeLits
+
+type family StripPrefix (prefix :: Symbol) (symbol :: Symbol) :: Symbol where
+  StripPrefix prefix symbol =
+    FromList
+      ( FromMaybe
+          (ToList symbol)
+          ( StripPrefixL (ToList prefix) (ToList symbol)
+          )
+      )
+
+type family StripPrefixL (prefix :: [Symbol]) (symbol :: [Symbol]) :: Maybe [Symbol] where
+  StripPrefixL '[] symbol = 'Just symbol
+  StripPrefixL _ '[] = 'Just '[]
+  StripPrefixL (p ': ps) (p ': ss) = StripPrefixL ps ss
+  StripPrefixL (p ': ps) (s ': ss) = 'Nothing
+
+type family FromMaybe (def :: a) (maybe :: Maybe a) :: a where
+  FromMaybe def 'Nothing = def
+  FromMaybe def ( 'Just a) = a
+
+type family FromList (list :: [Symbol]) :: Symbol where
+  FromList '[] = ""
+  FromList (x ': xs) = AppendSymbol x (FromList xs)

--- a/src/GHC/TypeLits/Extra/Symbol.hs
+++ b/src/GHC/TypeLits/Extra/Symbol.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- TODO: Upstream this to symbols package
+-- https://github.com/kcsongor/symbols/issues/3
 module GHC.TypeLits.Extra.Symbol where
 
 import Data.Symbol.Ascii


### PR DESCRIPTION
[Merges to #93]

Given the route:

```haskell
data R = R_Index | R_Foo | R_Bar NumRoute | R_Bar2 NumRoute
```

we want to determine this type generically:

```haskell
  type
    MotleyRouteSubRoutes R =
      '[ SingletonRoute "index.html"
       , SingletonRoute "foo.html"
       , PrefixedRoute "bar" NumRoute
       , PrefixedRoute "bar2" NumRoute
       ]
```

In particular, "Foo_BarQux" constructor should map to "bar-qux.html". This requires type-level `Symbol` processing.

**Tasks**

- [x] Initial generic implementation
- [x] Type-level `Symbol` formatting
  - [ ] ~~Use GHC 9.2, but support lower versions disabling generic deriving (due to `UnconsSymbol` unavailability)?. nixpkgs doesn't have 9.2 cached yet, so Emanote must remain in 9.0. But this is problematic for ema-template which ought to use generic route deriving. #97~~