### PR TITLE
Switch to 9.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,29 @@
         "type": "github"
       }
     },
+    "relude": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654789035,
+        "narHash": "sha256-57pQicQBHQ7T9NCuR7YnRt7E6m+tVNLE8LyJV4MtpMU=",
+        "owner": "kowainik",
+        "repo": "relude",
+        "rev": "b2fccefa4b81ead3aeec567e2f536498dec5eee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kowainik",
+        "ref": "v1.1.0.0",
+        "repo": "relude",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "relude": "relude"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
           overrides = self: super: with pkgs.haskell.lib; {
             relude = dontCheck super.relude;
             retry = dontCheck super.retry;
+            http2 = dontCheck super.http2; # Fails on darwin
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,11 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs.follows = "nixpkgs";
     haskell-flake.url = "github:srid/haskell-flake";
+    # 1.1 not in nixpkgs or cabal hases yet 
+    relude.url = "github:kowainik/relude/v1.1.0.0";
+    relude.flake = false;
   };
-  outputs = { self, nixpkgs, flake-parts, haskell-flake, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-parts, haskell-flake, ... }:
     flake-parts.lib.mkFlake { inherit self; } {
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
@@ -25,8 +28,8 @@
               cabal-fmt
               ormolu;
           };
-          overrides = self: super: with pkgs.haskell.lib; {
-            relude = self.callHackage "relude" "1.1.0.0" { }; # 1.1 required for GHC 9.2
+          source-overrides = {
+            inherit (inputs) relude;
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,9 @@
           source-overrides = {
             inherit (inputs) relude;
           };
+          overrides = self: super: with pkgs.haskell.lib; {
+            relude = dontCheck super.relude;
+          };
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,6 @@
               treefmt
               nixpkgs-fmt;
             inherit (hp)
-              cabal-fmt
               ormolu;
           };
           source-overrides = {

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
         # This attr is provided by https://github.com/srid/haskell-flake
         haskellProjects.default = {
           root = ./.;
+          haskellPackages = pkgs.haskell.packages.ghc922; # Needed for `UnconsSymbol`
           buildTools = hp: {
             inherit (pkgs)
               treefmt

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,21 @@
         haskellProjects.default = {
           root = ./.;
           haskellPackages = pkgs.haskell.packages.ghc922; # Needed for `UnconsSymbol`
-          buildTools = hp: {
-            inherit (pkgs)
-              treefmt
-              nixpkgs-fmt;
-            inherit (hp)
-              ormolu;
-          };
+          buildTools = hp:
+            let
+              # https://github.com/NixOS/nixpkgs/issues/140774
+              workaround140774 = hpkg: with pkgs.haskell.lib;
+                overrideCabal hpkg (drv: {
+                  enableSeparateBinOutput = false;
+                });
+            in
+            {
+              inherit (pkgs)
+                treefmt
+                nixpkgs-fmt;
+              ormolu = workaround140774 hp.ormolu;
+              ghcid = workaround140774 hp.ghcid;
+            };
           source-overrides = {
             inherit (inputs) relude;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
           };
           overrides = self: super: with pkgs.haskell.lib; {
             relude = dontCheck super.relude;
+            retry = dontCheck super.retry;
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,9 @@
               cabal-fmt
               ormolu;
           };
+          overrides = self: super: with pkgs.haskell.lib; {
+            relude = self.callHackage "relude" "1.1.0.0" { }; # 1.1 required for GHC 9.2
+          };
         };
       };
     };

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -15,7 +15,8 @@ includes = ["*.hs"]
 command = "nixpkgs-fmt"
 includes = ["*.nix"]
 
-[formatter.cabal]
-command = "cabal-fmt"
-options = ["--inplace"]
-includes = ["*.cabal"]
+# https://github.com/srid/ema/pull/97#issuecomment-1166589918
+# [formatter.cabal]
+# command = "cabal-fmt"
+# options = ["--inplace"]
+# includes = ["*.cabal"]


### PR DESCRIPTION
Required to do #96 - to use https://hackage.haskell.org/package/base-4.16.1.0/docs/GHC-TypeLits.html#t:UnconsSymbol

We still want to support 9.0, inasmuch as nixpkgs has that version cached.

ema-template will have to use 9.2 if it needs generic deriving, but we can instruct users to use the garnix cache to avoid building of the universe.