### PR TITLE
GHC 9.2, take 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,10 @@
 name: "CI"
 on:
-  pull_request:
+  # Disable this action until 9.2 gets into nixpkgs cache
+  # pull_request:
   push:
+    branches-ignore:
+      - "**"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,29 @@
         "type": "github"
       }
     },
+    "relude": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654789035,
+        "narHash": "sha256-57pQicQBHQ7T9NCuR7YnRt7E6m+tVNLE8LyJV4MtpMU=",
+        "owner": "kowainik",
+        "repo": "relude",
+        "rev": "b2fccefa4b81ead3aeec567e2f536498dec5eee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kowainik",
+        "ref": "v1.1.0.0",
+        "repo": "relude",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "relude": "relude"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             relude = dontCheck super.relude;
             retry = dontCheck super.retry;
             http2 = dontCheck super.http2; # Fails on darwin
+            # streaming-commons = dontCheck super.streaming-commons; # Fails on darwin
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
             relude = dontCheck super.relude;
             retry = dontCheck super.retry;
             http2 = dontCheck super.http2; # Fails on darwin
-            # streaming-commons = dontCheck super.streaming-commons; # Fails on darwin
+            streaming-commons = dontCheck super.streaming-commons; # Fails on darwin
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs.follows = "nixpkgs";
     haskell-flake.url = "github:srid/haskell-flake";
-    # 1.1 not in nixpkgs or cabal hases yet 
+    # 1.1 not in nixpkgs or cabal hasesh yet 
     relude.url = "github:kowainik/relude/v1.1.0.0";
     relude.flake = false;
   };
@@ -22,7 +22,7 @@
           haskellPackages = pkgs.haskell.packages.ghc922; # Needed for `UnconsSymbol`
           buildTools = hp:
             let
-              # https://github.com/NixOS/nixpkgs/issues/140774
+              # https://github.com/NixOS/nixpkgs/issues/140774 reoccurs in GHC 9.2
               workaround140774 = hpkg: with pkgs.haskell.lib;
                 overrideCabal hpkg (drv: {
                   enableSeparateBinOutput = false;
@@ -39,6 +39,7 @@
             inherit (inputs) relude;
           };
           overrides = self: super: with pkgs.haskell.lib; {
+            # All these below are for GHC 9.2 compat.
             relude = dontCheck super.relude;
             retry = dontCheck super.retry;
             http2 = dontCheck super.http2; # Fails on darwin

--- a/src/Ema/CLI.hs
+++ b/src/Ema/CLI.hs
@@ -47,10 +47,10 @@ isLiveServer _ = False
 
 -- | Ema's command-line interface options
 data Cli = Cli
-  { -- | The Ema action to run
-    action :: Some Action
-  , -- | Logging verbosity
-    verbose :: Bool
+  { action :: Some Action
+  -- ^ The Ema action to run
+  , verbose :: Bool
+  -- ^ Logging verbosity
   }
   deriving stock (Eq, Show)
 

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -15,7 +15,8 @@ includes = ["*.hs"]
 command = "nixpkgs-fmt"
 includes = ["*.nix"]
 
-[formatter.cabal]
-command = "cabal-fmt"
-options = ["--inplace"]
-includes = ["*.cabal"]
+# https://github.com/srid/ema/pull/97#issuecomment-1166589918
+# [formatter.cabal]
+# command = "cabal-fmt"
+# options = ["--inplace"]
+# includes = ["*.cabal"]


### PR DESCRIPTION
#97 was closed, but given the compile slowness with using the `symbols` package (https://github.com/srid/ema/pull/96#issuecomment-1166618912), `UnconsSymbol` of 9.2 seems to be necessary.