### PR TITLE
Refactor server

### DIFF
--- a/ema/src/Ema/Server.hs
+++ b/ema/src/Ema/Server.hs
@@ -84,59 +84,60 @@ runServerWithWebSocketHotReload host mport model = do
           Warp.runSettings (settings & Warp.setPort port) app
     wsApp logger pendingConn = do
       conn :: WS.Connection <- WS.acceptRequest pendingConn
-      WS.withPingThread conn 30 pass $
-        flip runLoggingT logger $ do
-          subId <- LVar.addListener model
-          let log lvl (s :: Text) =
-                logWithoutLoc (toText @String $ printf "ema.ws.%.2d" subId) lvl s
-          log LevelInfo "Connected"
-          let askClientForRoute = do
-                msg :: Text <- liftIO $ WS.receiveData conn
-                log LevelDebug $ "<~~ " <> show msg
-                pure msg
-              sendRouteHtmlToClient path m =
-                case decodeUrlRoute @r m path of
-                  Left err -> do
-                    log LevelError $ badRouteEncodingMsg err
-                    liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse $ badRouteEncodingMsg err
-                  Right Nothing ->
-                    liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse decodeRouteNothingMsg
-                  Right (Just r) -> do
-                    renderCatchingErrors m r >>= \case
-                      AssetGenerated Html html ->
-                        liftIO $ WS.sendTextData conn $ html <> toLazy wsClientHtml
-                      -- HACK: We expect the websocket client should check for REDIRECT prefix.
-                      -- Not bothering with JSON response to avoid having to JSON parse every HTML dump.
-                      AssetStatic _staticPath ->
-                        liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism m) r)
-                      AssetGenerated Other _s ->
-                        liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism m) r)
-                    log LevelDebug $ " ~~> " <> show r
-              loop mWatchingRoute = do
-                -- Listen *until* either we get a new value, or the client requests
-                -- to switch to a new route.
-                race (LVar.listenNext model subId) askClientForRoute >>= \case
-                  Left newModel -> do
-                    -- The page the user is currently viewing has changed. Send
-                    -- the new HTML to them.
-                    sendRouteHtmlToClient mWatchingRoute newModel
-                    loop mWatchingRoute
-                  Right mNextRoute -> do
-                    -- The user clicked on a route link; send them the HTML for
-                    -- that route this time, ignoring what we are watching
-                    -- currently.
-                    sendRouteHtmlToClient mNextRoute =<< LVar.get model
-                    loop mNextRoute
-          mInitialRoute <- askClientForRoute
-          try (loop mInitialRoute) >>= \case
-            Right () -> pass
-            Left (connExc :: ConnectionException) -> do
-              case connExc of
-                WS.CloseRequest _ (decodeUtf8 -> reason) ->
-                  log LevelInfo $ "Closing websocket connection (reason: " <> reason <> ")"
-                _ ->
-                  log LevelError $ "Websocket error: " <> show connExc
-              LVar.removeListener model subId
+      (\x -> x) $
+        WS.withPingThread conn 30 pass $
+          flip runLoggingT logger $ do
+            subId <- LVar.addListener model
+            let log lvl (s :: Text) =
+                  logWithoutLoc (toText @String $ printf "ema.ws.%.2d" subId) lvl s
+            log LevelInfo "Connected"
+            let askClientForRoute = do
+                  msg :: Text <- liftIO $ WS.receiveData conn
+                  log LevelDebug $ "<~~ " <> show msg
+                  pure msg
+                sendRouteHtmlToClient path m =
+                  case decodeUrlRoute @r m path of
+                    Left err -> do
+                      log LevelError $ badRouteEncodingMsg err
+                      liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse $ badRouteEncodingMsg err
+                    Right Nothing ->
+                      liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse decodeRouteNothingMsg
+                    Right (Just r) -> do
+                      renderCatchingErrors m r >>= \case
+                        AssetGenerated Html html ->
+                          liftIO $ WS.sendTextData conn $ html <> toLazy wsClientHtml
+                        -- HACK: We expect the websocket client should check for REDIRECT prefix.
+                        -- Not bothering with JSON response to avoid having to JSON parse every HTML dump.
+                        AssetStatic _staticPath ->
+                          liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism m) r)
+                        AssetGenerated Other _s ->
+                          liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism m) r)
+                      log LevelDebug $ " ~~> " <> show r
+                loop mWatchingRoute = do
+                  -- Listen *until* either we get a new value, or the client requests
+                  -- to switch to a new route.
+                  race (LVar.listenNext model subId) askClientForRoute >>= \case
+                    Left newModel -> do
+                      -- The page the user is currently viewing has changed. Send
+                      -- the new HTML to them.
+                      sendRouteHtmlToClient mWatchingRoute newModel
+                      loop mWatchingRoute
+                    Right mNextRoute -> do
+                      -- The user clicked on a route link; send them the HTML for
+                      -- that route this time, ignoring what we are watching
+                      -- currently.
+                      sendRouteHtmlToClient mNextRoute =<< LVar.get model
+                      loop mNextRoute
+            mInitialRoute <- askClientForRoute
+            try (loop mInitialRoute) >>= \case
+              Right () -> pass
+              Left (connExc :: ConnectionException) -> do
+                case connExc of
+                  WS.CloseRequest _ (decodeUtf8 -> reason) ->
+                    log LevelInfo $ "Closing websocket connection (reason: " <> reason <> ")"
+                  _ ->
+                    log LevelError $ "Websocket error: " <> show connExc
+                LVar.removeListener model subId
     httpApp logger req f = do
       flip runLoggingT logger $ do
         val <- LVar.get model

--- a/ema/src/Ema/Server.hs
+++ b/ema/src/Ema/Server.hs
@@ -96,7 +96,7 @@ runServerWithWebSocketHotReload host mport model = do
                   log LevelDebug $ "<~~ " <> show msg
                   pure msg
                 sendRouteHtmlToClient path m =
-                  case decodeUrlRoute @r m path of
+                  case decodeUrlRoute m path of
                     Left err -> do
                       log LevelError $ badRouteEncodingMsg err
                       liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse $ badRouteEncodingMsg err

--- a/ema/src/Ema/Server.hs
+++ b/ema/src/Ema/Server.hs
@@ -116,18 +116,19 @@ runServerWithWebSocketHotReload host mport model = do
                 loop mWatchingRoute = do
                   -- Listen *until* either we get a new value, or the client requests
                   -- to switch to a new route.
-                  race (LVar.listenNext model subId) askClientForRoute >>= \case
-                    Left newModel -> do
-                      -- The page the user is currently viewing has changed. Send
-                      -- the new HTML to them.
-                      sendRouteHtmlToClient mWatchingRoute newModel
-                      loop mWatchingRoute
-                    Right mNextRoute -> do
-                      -- The user clicked on a route link; send them the HTML for
-                      -- that route this time, ignoring what we are watching
-                      -- currently.
-                      sendRouteHtmlToClient mNextRoute =<< LVar.get model
-                      loop mNextRoute
+                  (\x -> x) $
+                    race (LVar.listenNext model subId) askClientForRoute >>= \case
+                      Left newModel -> do
+                        -- The page the user is currently viewing has changed. Send
+                        -- the new HTML to them.
+                        sendRouteHtmlToClient mWatchingRoute newModel
+                        loop mWatchingRoute
+                      Right mNextRoute -> do
+                        -- The user clicked on a route link; send them the HTML for
+                        -- that route this time, ignoring what we are watching
+                        -- currently.
+                        sendRouteHtmlToClient mNextRoute =<< LVar.get model
+                        loop mNextRoute
             mInitialRoute <- askClientForRoute
             try (loop mInitialRoute) >>= \case
               Right () -> pass

--- a/ema/src/Ema/Server.hs
+++ b/ema/src/Ema/Server.hs
@@ -5,8 +5,6 @@
 
 module Ema.Server where
 
-import Control.Concurrent.Async (race)
-import Control.Exception (try)
 import Control.Monad.Logger
 import Data.FileEmbed
 import Data.LVar (LVar)
@@ -36,8 +34,9 @@ import Network.WebSockets qualified as WS
 import Optics.Core (review)
 import Text.Printf (printf)
 import UnliftIO (MonadUnliftIO)
+import UnliftIO.Async (race)
 import UnliftIO.Concurrent (threadDelay)
-import UnliftIO.Exception (catch)
+import UnliftIO.Exception (catch, try)
 
 runServerWithWebSocketHotReload ::
   forall r m.
@@ -62,7 +61,7 @@ runServerWithWebSocketHotReload host mport model = do
       app =
         WaiWs.websocketsOr
           WS.defaultConnectionOptions
-          (runM . wsApp)
+          (wsApp logger)
           (httpApp logger)
       banner port = do
         logInfoNS "ema" "==============================================="
@@ -83,82 +82,68 @@ runServerWithWebSocketHotReload host mport model = do
         Just port -> do
           void $ banner port
           Warp.runSettings (settings & Warp.setPort port) app
-    wsApp pendingConn = do
-      conn :: WS.Connection <- lift $ WS.acceptRequest pendingConn
-      logger <- askLoggerIO
-      lift $
-        WS.withPingThread conn 30 pass $
-          flip runLoggingT logger $ do
-            subId <- LVar.addListener model
-            let log lvl (s :: Text) =
-                  logWithoutLoc (toText @String $ printf "ema.ws.%.2d" subId) lvl s
-            log LevelInfo "Connected"
-            let askClientForRoute = do
-                  msg :: Text <- liftIO $ WS.receiveData conn
-                  -- TODO: Let non-html routes pass through.
-                  let pathInfo = pathInfoFromWsMsg msg
-                  log LevelDebug $ "<~~ " <> show pathInfo
-                  pure pathInfo
-                decodeRouteWithCurrentModel pathInfo = do
-                  val <- LVar.get model
-                  pure $ routeFromPathInfo val pathInfo
-                sendRouteHtmlToClient pathInfo s = do
-                  decodeRouteWithCurrentModel pathInfo >>= \case
-                    Left err -> do
-                      log LevelError $ badRouteEncodingMsg err
-                      liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse $ badRouteEncodingMsg err
-                    Right Nothing ->
-                      liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse decodeRouteNothingMsg
-                    Right (Just r) -> do
-                      renderCatchingErrors s r >>= \case
-                        AssetGenerated Html html ->
-                          liftIO $ WS.sendTextData conn $ html <> toLazy wsClientHtml
-                        -- HACK: We expect the websocket client should check for REDIRECT prefix.
-                        -- Not bothering with JSON response to avoid having to JSON parse every HTML dump.
-                        AssetStatic _staticPath ->
-                          liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ enc s) r)
-                        AssetGenerated Other _s ->
-                          liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ enc s) r)
-                      log LevelDebug $ " ~~> " <> show r
-                loop = flip runLoggingT logger $ do
-                  -- Notice that we @askClientForRoute@ in succession twice here.
-                  -- The first route will be the route the client intends to observe
-                  -- for changes on. The second route, *if* it is sent, indicates
-                  -- that the client wants to *switch* to that route. This proecess
-                  -- repeats ad infinitum: i.e., the third route is for observing
-                  -- changes, the fourth route is for switching to, and so on.
-                  mWatchingRoute <- askClientForRoute
-                  -- Listen *until* either we get a new value, or the client requests
-                  -- to switch to a new route.
-                  liftIO $ do
-                    race (LVar.listenNext model subId) (runLoggingT askClientForRoute logger) >>= \res -> flip runLoggingT logger $ case res of
-                      Left newModel -> do
-                        -- The page the user is currently viewing has changed. Send
-                        -- the new HTML to them.
-                        sendRouteHtmlToClient mWatchingRoute newModel
-                        lift loop
-                      Right mNextRoute -> do
-                        -- The user clicked on a route link; send them the HTML for
-                        -- that route this time, ignoring what we are watching
-                        -- currently (we expect the user to initiate a watch route
-                        -- request immediately following this).
-                        sendRouteHtmlToClient mNextRoute =<< LVar.get model
-                        lift loop
-            liftIO (try loop) >>= \case
-              Right () -> pass
-              Left (connExc :: ConnectionException) -> do
-                case connExc of
-                  WS.CloseRequest _ (decodeUtf8 -> reason) ->
-                    log LevelInfo $ "Closing websocket connection (reason: " <> reason <> ")"
-                  _ ->
-                    log LevelError $ "Websocket error: " <> show connExc
-                LVar.removeListener model subId
+    wsApp logger pendingConn = do
+      conn :: WS.Connection <- WS.acceptRequest pendingConn
+      WS.withPingThread conn 30 pass $
+        flip runLoggingT logger $ do
+          subId <- LVar.addListener model
+          let log lvl (s :: Text) =
+                logWithoutLoc (toText @String $ printf "ema.ws.%.2d" subId) lvl s
+          log LevelInfo "Connected"
+          let askClientForRoute = do
+                msg :: Text <- liftIO $ WS.receiveData conn
+                log LevelDebug $ "<~~ " <> show msg
+                pure msg
+              sendRouteHtmlToClient path m =
+                case decodeUrlRoute @r m path of
+                  Left err -> do
+                    log LevelError $ badRouteEncodingMsg err
+                    liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse $ badRouteEncodingMsg err
+                  Right Nothing ->
+                    liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse decodeRouteNothingMsg
+                  Right (Just r) -> do
+                    renderCatchingErrors m r >>= \case
+                      AssetGenerated Html html ->
+                        liftIO $ WS.sendTextData conn $ html <> toLazy wsClientHtml
+                      -- HACK: We expect the websocket client should check for REDIRECT prefix.
+                      -- Not bothering with JSON response to avoid having to JSON parse every HTML dump.
+                      AssetStatic _staticPath ->
+                        liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism m) r)
+                      AssetGenerated Other _s ->
+                        liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism m) r)
+                    log LevelDebug $ " ~~> " <> show r
+              loop mWatchingRoute = do
+                -- Listen *until* either we get a new value, or the client requests
+                -- to switch to a new route.
+                race (LVar.listenNext model subId) askClientForRoute >>= \case
+                  Left newModel -> do
+                    -- The page the user is currently viewing has changed. Send
+                    -- the new HTML to them.
+                    sendRouteHtmlToClient mWatchingRoute newModel
+                    loop mWatchingRoute
+                  Right mNextRoute -> do
+                    -- The user clicked on a route link; send them the HTML for
+                    -- that route this time, ignoring what we are watching
+                    -- currently.
+                    sendRouteHtmlToClient mNextRoute =<< LVar.get model
+                    loop mNextRoute
+          mInitialRoute <- askClientForRoute
+          try (loop mInitialRoute) >>= \case
+            Right () -> pass
+            Left (connExc :: ConnectionException) -> do
+              case connExc of
+                WS.CloseRequest _ (decodeUtf8 -> reason) ->
+                  log LevelInfo $ "Closing websocket connection (reason: " <> reason <> ")"
+                _ ->
+                  log LevelError $ "Websocket error: " <> show connExc
+              LVar.removeListener model subId
     httpApp logger req f = do
       flip runLoggingT logger $ do
         val <- LVar.get model
-        let path = Wai.pathInfo req
-            mr = routeFromPathInfo val path
-        logInfoNS "ema.http" $ "GET " <> ("/" <> T.intercalate "/" path) <> " as " <> show mr
+        let pathInfo = Wai.pathInfo req
+            path = T.intercalate "/" pathInfo
+            mr = decodeUrlRoute val path
+        logInfoNS "ema.http" $ "GET " <> path <> " as " <> show mr
         case mr of
           Left err -> do
             logErrorNS "App" $ badRouteEncodingMsg err
@@ -178,24 +163,30 @@ runServerWithWebSocketHotReload host mport model = do
               AssetGenerated Other s -> do
                 let mimeType = Static.getMimeType $ review (fromPrism_ $ enc val) r
                 liftIO $ f $ Wai.responseLBS H.status200 [(H.hContentType, mimeType)] s
-    renderCatchingErrors m r =
-      catch (siteOutput (fromPrism_ $ enc m) m r) $ \(err :: SomeException) -> do
-        -- Log the error first.
-        logErrorNS "App" $ show @Text err
-        pure $
-          AssetGenerated Html . mkHtmlErrorMsg $
-            show @Text err
-    routeFromPathInfo m =
-      decodeUrlRoute m . T.intercalate "/"
-    -- Decode an URL path into a route
-    --
-    -- This function is used only in live server. If the route is not
-    -- isomoprhic, this returns a Left, with the mismatched encoding.
-    decodeUrlRoute :: RouteModel r -> Text -> Either (BadRouteEncoding r) (Maybe r)
-    decodeUrlRoute m (urlToFilePath -> s) = do
-      case checkRoutePrismGivenFilePath enc m s of
-        Left (r, log) -> Left $ BadRouteEncoding s r log
-        Right mr -> Right mr
+
+renderCatchingErrors ::
+  (EmaStaticSite r, MonadUnliftIO m, MonadLoggerIO m) =>
+  RouteModel r ->
+  r ->
+  m (Asset LByteString)
+renderCatchingErrors m r =
+  catch (siteOutput (fromPrism_ $ routePrism m) m r) $ \(err :: SomeException) -> do
+    -- Log the error first.
+    logErrorNS "App" $ show @Text err
+    pure $
+      AssetGenerated Html . mkHtmlErrorMsg $
+        show @Text err
+
+{- | Decode an URL path into a route
+
+ This function is used only in live server. If the route is not
+ isomoprhic, this returns a Left, with the mismatched encoding.
+-}
+decodeUrlRoute :: (Eq r, Show r, IsRoute r) => RouteModel r -> Text -> Either (BadRouteEncoding r) (Maybe r)
+decodeUrlRoute m (urlToFilePath -> s) = do
+  case checkRoutePrismGivenFilePath routePrism m s of
+    Left (r, log) -> Left $ BadRouteEncoding s r log
+    Right mr -> Right mr
 
 -- | A basic error response for displaying in the browser
 emaErrorHtmlResponse :: Text -> LByteString
@@ -205,13 +196,6 @@ emaErrorHtmlResponse err =
 mkHtmlErrorMsg :: Text -> LByteString
 mkHtmlErrorMsg s =
   encodeUtf8 . T.replace "MESSAGE" s . decodeUtf8 $ $(embedFile "www/ema-error.html")
-
-{- | Return the equivalent of WAI's @pathInfo@, from the raw path string
- (`document.location.pathname`) the browser sends us.
--}
-pathInfoFromWsMsg :: Text -> [Text]
-pathInfoFromWsMsg =
-  filter (/= "") . T.splitOn "/" . T.drop 1
 
 decodeRouteNothingMsg :: Text
 decodeRouteNothingMsg = "Ema: 404 (route decoding returned Nothing)"

--- a/ema/www/ema-shim.js
+++ b/ema/www/ema-shim.js
@@ -73,7 +73,7 @@ function init(reconnecting) {
     let ws = new WebSocket(wsUrl);
 
     function sendObservePath(path) {
-        const relPath = path.startsWith(basePath) ? path.slice(basePath.length - 1) : path;
+        const relPath = path.startsWith(basePath) ? path.slice(basePath.length) : path;
         console.debug(`ema: requesting ${relPath}`);
         ws.send(relPath);
     }
@@ -167,7 +167,6 @@ function init(reconnecting) {
             if (window.location.hash) {
                 scrollToAnchor(window.location.hash);
             }
-            watchCurrentRoute();
         };
     };
     window.onbeforeunload = evt => { ws.close(); };


### PR DESCRIPTION
Simplifies the websocket loop logic from "wait for two messages, first
one tells the current open route (to be watched), second one tells the
route to be sent" to "on every message, switch to its route and remember
that it is being watched".

Removes routeFromPathInfo (that would always strip the first character
from the websocket message) and instead assumes the js shim strips the
base path completely.

This is in preparation to the server customization feature.

Also simplify parts of the runServerWithWebSocketHotReload function.