### PR TITLE
Show help for individual commands

### DIFF
--- a/ema/src/Ema/CLI.hs
+++ b/ema/src/Ema/CLI.hs
@@ -61,9 +61,10 @@ instance Default Cli where
 cliParser :: Parser Cli
 cliParser = do
   action <-
-    subparser
-      (command "gen" (info generate (progDesc "Generate static site")))
-      <|> subparser (command "run" (info run (progDesc "Run the live server")))
+    hsubparser
+      ( command "gen" (info generate (progDesc "Generate static site"))
+          <> command "run" (info run (progDesc "Run the live server"))
+      )
       <|> pure (Some $ Run def)
   verbose <- switch (long "verbose" <> short 'v' <> help "Enable verbose logging")
   pure Cli {..}


### PR DESCRIPTION
Makes the Ema CLI show help pages for "gen" and "run" individually.