### PR TITLE
Allow skipping re-creation of <script> tags

### DIFF
--- a/docs/topics/hot-reload.md
+++ b/docs/topics/hot-reload.md
@@ -15,6 +15,10 @@ The Ema dev server uses websockets to keep a bi-directional connection open betw
 
 When switching to a new route or when receiving the new HTML, Ema uses [idiomorph](https://github.com/bigskysoftware/idiomorph) to _patch_ the existing DOM tree rather than replace it in its entirety. This, in addition to use of websockets, makes it possible to support **instant** hot reload with nary a delay.
 
+In addition to the patching the DOM, all `<script>` tags are recreated, making it possible to re-run any JavaScript code (e.g.: for [syntax highlighting][syn]) that was present in the new HTML. You can skip this behaviour on a per-`<script>`-tag basis by using the `data-ema-skip=true` custom attribute (Emanote does this for Tailwind, to prevent it from inserting [duplicate](https://github.com/srid/emanote/issues/411) `<style>` tags).
+
+[syn]: https://emanote.srid.ca/tips/js/syntax-highlighting
+
 ### Haskell reload
 
 Finally, hot reload on _code_ changes are supported via [ghcid](https://github.com/ndmitchell/ghcid). The [template repo](https://github.com/srid/ema-template)'s `bin/run` script uses ghcid underneath. Any HTML DSL (like `blaze-html`) or CSS DSL automatically gets supported for hot-reload. If you choose to use a file-based HTML template language, you can enable hot-reload on template change using the [[unionmount]] library.

--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -6,11 +6,12 @@
 - API changes
   - `Ema.CLI`: The `Action` type is no longer a GADT.
   - `Ema.Server`: This module has be split into several smaller modules
-- Live server: 
+- Live server:
   - Shim/websocket customization ([\#152](https://github.com/srid/ema/pull/152)) @lucasvreis
   - Fix scrolling to page end when using pathname in anchor links (\#162)
   - Add `--no-ws` to disable websocket handling in live server (\#161)
   - Switch from `morphdom` to `idiomorph`
+  - Allow skipping recreation of any `<script>` tag during live server update by using `data-ema-skip=true` custom attribute (\#170)
 
 ## 0.10.2.0 (2023-08-09)
 
@@ -40,7 +41,7 @@ This releases brings a significant rewrite of Ema. If you choose to upgrade your
   - Represent route encoding using `Prism'` from optics-core; add `IsRoute` class to define them.
     - Optional generic deriving of route prisms, so you do not have to hand-write them.
     - Automatic isomorphism checks ensures that encoding and decoding are isomorphic (route prisms are lawful)
-  - Composable Ema apps 
+  - Composable Ema apps
     - There are two ways of composing Ema apps. Using heterogenous lists (see `Ema.Route.Lib.Multi`), or by defining a top-level route type (see `Ex04_Multi.hs`).
   - Replace `LVar` with `Dynamic`.
     - Ema still uses `LVar` internally (for live server updates), but on the user-side one only needs to provide a `Dynamic` which is a tuple of initial value and an updating function. The [unionmount](https://github.com/srid/unionmount/pull/1) library was changed to provide this tuple.
@@ -67,7 +68,7 @@ This releases brings a significant rewrite of Ema. If you choose to upgrade your
 - Remove unused Cabal deps (#61)
 - `Tailwind.layoutWith`: don't hardcode `<body>` attrs
 - Tailwind: module revamped and renamed to `Tailwind.Helper.Blaze`
-- `runEma` and friends: 
+- `runEma` and friends:
   - return the monadic's action's return value or generated files (dependent type)
 - CLI: add `run` subcommand that takes `--host` and `--port` (and remove environment hacks of $HOST and $PORT)
 
@@ -84,12 +85,12 @@ This releases brings a significant rewrite of Ema. If you choose to upgrade your
   - Do not handle target=_blank links in websocket route switch
 - `Asset` type
   - Introduce the `Asset` type to distinguishing between static files and generated files. The later can be one of `Html` or `Other`, allowing the live server to handle them sensibly.
-  - `Ema` typeclass: 
+  - `Ema` typeclass:
     - Drop `staticAssets` in favour of `allRoutes` (renamed from `staticRoutes`) returning all routes including both generated and static routes.
     - Drop `Slug` and use plain `FilePath`. Route encoder and decoder deal directly with the on-disk path of the generated (or static) files.
   - Make the render function (which `runEma` takes) return a `Asset LByteString` instead of `LByteString` such that it can handle all routes, and handle static files as well as generation of non-HTML content (eg: RSS)
   - Allow copying static files anywhere on the filesystem
-- `routeUrl`: 
+- `routeUrl`:
   - Unicode normalize as well URI encode route URLs
   - now returns relative URLs (ie. without the leading `/`)
     - Use the `<base>` tag to specify an explicit prefix for relative URLs in generated HTML. This way hosting on GitHub Pages without CNAME will continue to have functional links.

--- a/ema/www/ema-shim.js
+++ b/ema/www/ema-shim.js
@@ -12,6 +12,11 @@ function setHtml(elm, html) {
 // See also the HACK below in one of the invocations.
 function reloadScripts(elm) {
   Array.from(elm.querySelectorAll("script")).forEach((oldScript) => {
+    // Some scripts, like Tailwind, should not be reloaded (they are not idempotent)
+    // Allow the user to skip such scripts with a data-* attribute
+    if (oldScript.getAttribute("data-ema-skip") === "true") {
+      return;
+    }
     const newScript = document.createElement("script");
     Array.from(oldScript.attributes).forEach((attr) =>
       newScript.setAttribute(attr.name, attr.value),


### PR DESCRIPTION
Some JavaScript programs are not idempotent. This flag allows ignoring those.

Resolves #169
