### PR TITLE
refactor: Simplify and clean up Haskell codebase

### DIFF
--- a/ema-generics/src/Ema/Route/Generic.hs
+++ b/ema-generics/src/Ema/Route/Generic.hs
@@ -32,6 +32,7 @@ import Ema.Route.Lib.Folder (FolderRoute (FolderRoute))
 import Ema.Route.Lib.Multi (MultiModel, MultiRoute)
 import Ema.Route.Prism.Type (mapRoutePrism)
 import GHC.Generics qualified as GHC
+import GHC.TypeLits.Extra.Symbol (FromMaybe)
 import Generics.SOP (All, I (..), NP)
 import Optics.Core (ReversibleOptic (re), coercedTo, equality, review, (%))
 import Prelude hiding (All, Generic)
@@ -106,10 +107,6 @@ type family OptSubRoutes r (opts :: [Type]) :: [Type] where
 type family OptSubModels r (opts :: [Type]) :: [Type] where
   OptSubModels r '[] = MultiModel (SubRoutes r)
   OptSubModels r (opt ': opts) = FromMaybe (OptSubModels r opts) (OptSubModelsM r opt)
-
-type family FromMaybe (def :: a) (maybe :: Maybe a) :: a where
-  FromMaybe def 'Nothing = def
-  FromMaybe def ('Just a) = a
 
 type GenericRouteOpts r opts = All (GenericRouteOpt r) opts
 

--- a/ema-generics/src/Ema/Route/Generic/RGeneric.hs
+++ b/ema-generics/src/Ema/Route/Generic/RGeneric.hs
@@ -74,7 +74,7 @@ type family GetConstructorNames (infos :: [SOPM.ConstructorInfo]) :: [SOPM.Const
   GetConstructorNames '[] = '[]
   GetConstructorNames (x ': xs) = GetConstructorName x ': GetConstructorNames xs
 
-{- | Class of `NP` that can be used in a route tyupe.
+{- | Class of `NP` that can be used in a route type.
 
     Ensures that the constructor can have 0 or 1 products only.
 -}

--- a/ema-generics/src/Ema/Route/Generic/Verification.hs
+++ b/ema-generics/src/Ema/Route/Generic/Verification.hs
@@ -47,7 +47,7 @@ type family VerifyRoutes (rcode :: [Type]) (subRoutes :: [Type]) :: Constraint w
           ':$$: 'Text ""
           ':$$: ('Text "\t" ':<>: 'ShowType t)
       )
-  -- Subroute rep is unit (REVIEW: this case not strictly necessary anymore; should it be removed?)
+  -- Terminal route: both sides are unit, no Coercible check needed.
   VerifyRoutes (() ': rs) (() : rs') = VerifyRoutes rs rs'
   VerifyRoutes (r' ': rs) (() : rs') =
     TypeError

--- a/ema-generics/src/GHC/TypeLits/Extra/Symbol.hs
+++ b/ema-generics/src/GHC/TypeLits/Extra/Symbol.hs
@@ -3,6 +3,7 @@
 module GHC.TypeLits.Extra.Symbol (
   StripPrefix,
   ToLower,
+  FromMaybe,
 ) where
 
 import GHC.TypeLits (ConsSymbol, Symbol, UnconsSymbol)

--- a/ema/src/Ema/App.hs
+++ b/ema/src/Ema/App.hs
@@ -90,16 +90,16 @@ runSiteWith cfg siteArg = do
         LVar.set model model0
         logger <- askLoggerIO
         let mWsOpts = if noWebSocket then Nothing else Just opts
+            runM = flip runLoggingT logger
         liftIO $
           race_
-            ( flip runLoggingT logger $ do
+            ( runM $ do
                 cont $ LVar.set model
                 logWarnNS "ema" "modelPatcher exited; no more model updates!"
-                -- We want to keep this thread alive, so that the server thread
-                -- doesn't exit.
+                -- Keep this thread alive so that race_ doesn't cancel the
+                -- server thread.
                 liftIO $ threadDelay maxBound
             )
-            ( flip runLoggingT logger $ do
-                Server.runServerWithWebSocketHotReload @r mWsOpts host mport model
+            ( runM $ Server.runServerWithWebSocketHotReload @r mWsOpts host mport model
             )
         CLI.crash "ema" "Live server unexpectedly stopped"

--- a/ema/src/Ema/CLI.hs
+++ b/ema/src/Ema/CLI.hs
@@ -105,9 +105,7 @@ getLogger cli =
   where
     allowLogLevelFrom :: LogLevel -> Logger -> Logger
     allowLogLevelFrom minLevel (Logger f) = Logger $ \loc src level msg ->
-      if level >= minLevel
-        then f loc src level msg
-        else pass
+      when (level >= minLevel) $ f loc src level msg
 
 {- | Crash the program with the given error message
 

--- a/ema/src/Ema/Dynamic.hs
+++ b/ema/src/Ema/Dynamic.hs
@@ -36,27 +36,30 @@ instance (MonadUnliftIO m, MonadLogger m) => Applicative (Dynamic m) where
       , \send -> do
           var <- newTVarIO (x0, y0)
           sendLock :: TMVar () <- newEmptyTMVarIO
+          let
+            -- Serialize updates through the lock, applying the STM action and
+            -- sending the result. This prevents interleaved updates from
+            -- producing inconsistent views.
+            lockedUpdate label stmAction = do
+              atomically $ putTMVar sendLock ()
+              logDebugNS "ema.dyn.app" label
+              send =<< atomically stmAction
+              atomically $ takeTMVar sendLock
+            -- Keep a thread alive after its updater exits, so race_ doesn't
+            -- cancel the other side.
+            keepAlive updater = do
+              updater
+              logDebugNS "ema.dyn.app" "updater exited; keeping thread alive"
+              threadDelay maxBound
           race_
-            ( do
-                xf $ \x -> do
-                  atomically $ putTMVar sendLock ()
-                  logDebugNS "ema.dyn.app" "left update"
-                  send <=< atomically $ do
-                    modifyTVar' var $ first (const x)
-                    f x . snd <$> readTVar var
-                  atomically $ takeTMVar sendLock
-                logDebugNS "ema.dyn.app" "updater exited; keeping thread alive"
-                threadDelay maxBound
+            ( keepAlive $ xf $ \x ->
+                lockedUpdate "left update" $ do
+                  modifyTVar' var $ first (const x)
+                  f x . snd <$> readTVar var
             )
-            ( do
-                yf $ \y -> do
-                  atomically $ putTMVar sendLock ()
-                  logDebugNS "ema.dyn.app" "right update"
-                  send <=< atomically $ do
-                    modifyTVar' var $ second (const y)
-                    (`f` y) . fst <$> readTVar var
-                  atomically $ takeTMVar sendLock
-                logDebugNS "ema.dyn.app" "updater exited; keeping thread alive"
-                threadDelay maxBound
+            ( keepAlive $ yf $ \y ->
+                lockedUpdate "right update" $ do
+                  modifyTVar' var $ second (const y)
+                  (`f` y) . fst <$> readTVar var
             )
       )

--- a/ema/src/Ema/Generate.hs
+++ b/ema/src/Ema/Generate.hs
@@ -104,11 +104,9 @@ generateSiteFromModel' dest model = do
 noBirdbrainedJekyll :: (MonadIO m, MonadLoggerIO m) => FilePath -> m ()
 noBirdbrainedJekyll dest = do
   let nojekyll = dest </> ".nojekyll"
-  liftIO (doesFileExist nojekyll) >>= \case
-    True -> pass
-    False -> do
-      log LevelInfo $ "Disabling Jekyll by writing " <> toText nojekyll
-      writeFileLBS nojekyll ""
+  unlessM (liftIO $ doesFileExist nojekyll) $ do
+    log LevelInfo $ "Disabling Jekyll by writing " <> toText nojekyll
+    writeFileLBS nojekyll ""
 
 newtype StaticAssetMissing = StaticAssetMissing FilePath
   deriving stock (Show)

--- a/ema/src/Ema/Route/Lib/Multi.hs
+++ b/ema/src/Ema/Route/Lib/Multi.hs
@@ -77,10 +77,8 @@ instance
         (siteOutput @r (rp % headRoute) m)
         (siteOutput @(MultiRoute rs) (rp % tailRoute) ms)
     where
-      tailRoute =
-        (prism' (toNS . Right) (fromNS >>> rightToMaybe))
-      headRoute =
-        (prism' (toNS . Left) (fromNS >>> leftToMaybe))
+      tailRoute = prism' (toNS . Right) (fromNS >>> rightToMaybe)
+      headRoute = prism' (toNS . Left) (fromNS >>> leftToMaybe)
 
 -- | Like `eitherRoutePrism` but uses sop-core types instead of Either/Product.
 nsRoutePrism ::

--- a/ema/src/Ema/Route/Prism/Check.hs
+++ b/ema/src/Ema/Route/Prism/Check.hs
@@ -46,11 +46,10 @@ checkRoutePrismGivenFilePath enc a s = do
 
 checkRoutePrism :: (Eq r, Show r) => (a -> Prism_ FilePath r) -> a -> r -> FilePath -> Either Text ()
 checkRoutePrism p a r s =
-  let (valid, checkLog) =
-        runWriter $ routePrismIsLawfulFor p a r s
-   in if valid
-        then Right ()
-        else Left $ "Unlawful route prism for route value '" <> show r <> "'\n- " <> T.intercalate "\n- " checkLog
+  let (valid, checkLog) = runWriter $ routePrismIsLawfulFor p a r s
+   in unless valid $
+        Left $
+          "Unlawful route prism for route value '" <> show r <> "'\n- " <> T.intercalate "\n- " checkLog
 
 {- | Check if the route @Prism_@ is lawful.
 
@@ -78,12 +77,8 @@ prismIsLawfulFor ::
   s ->
   Writer [Text] Bool
 prismIsLawfulFor p a s = do
-  -- TODO: The logging here could be improved.
-  -- log $ "Testing Partial ISO law for " <> show a <> " and " <> toText s
   let s' :: s = review p a
-  -- log $ "Prism actual encoding: " <> toText s'
-  let ma' :: Maybe a = preview p s'
-  -- log $ "Decoding of that encoding: " <> show ma'
+      ma' :: Maybe a = preview p s'
   unless (s == s') $
     log $
       toText s <> " /= " <> toText s' <> " (encoding of '" <> show a <> "')"

--- a/ema/src/Ema/Route/Url.hs
+++ b/ema/src/Ema/Route/Url.hs
@@ -8,8 +8,7 @@ module Ema.Route.Url (
   urlToFilePath,
 ) where
 
-import Data.Aeson (FromJSON (parseJSON), Value)
-import Data.Aeson.Types (Parser)
+import Data.Aeson (FromJSON (parseJSON))
 import Data.Text qualified as T
 import Network.URI.Slug qualified as Slug
 import Optics.Core (Prism', review)
@@ -67,11 +66,9 @@ data UrlStrategy
   deriving stock (Eq, Show, Ord, Generic)
 
 instance FromJSON UrlStrategy where
-  parseJSON val =
-    f UrlPretty "pretty" val <|> f UrlDirect "direct" val
-    where
-      f :: UrlStrategy -> Text -> Value -> Parser UrlStrategy
-      f c s v = do
-        x <- parseJSON v
-        guard $ x == s
-        pure c
+  parseJSON v = do
+    x :: Text <- parseJSON v
+    case x of
+      "pretty" -> pure UrlPretty
+      "direct" -> pure UrlDirect
+      _ -> fail $ "Unknown URL strategy: " <> toString x

--- a/ema/src/Ema/Server.hs
+++ b/ema/src/Ema/Server.hs
@@ -36,8 +36,7 @@ runServerWithWebSocketHotReload ::
   m ()
 runServerWithWebSocketHotReload mWsOpts host mport model = do
   logger <- askLoggerIO
-  let runM = flip runLoggingT logger
-      settings =
+  let settings =
         Warp.defaultSettings
           & Warp.setHost (fromString . toString . unHost $ host)
       app =
@@ -49,11 +48,11 @@ runServerWithWebSocketHotReload mWsOpts host mport model = do
               WS.defaultConnectionOptions
               (wsApp @r logger model $ emaWebSocketServerHandler opts)
               (httpApp @r logger model $ Just $ emaWebSocketClientShim opts)
-      banner port = do
+      banner port = flip runLoggingT logger $ do
         logInfoNS "ema" "==============================================="
         logInfoNS "ema" $ "Ema live server RUNNING: http://" <> unHost host <> ":" <> show port <> " (" <> maybe "no ws" (const "ws") mWsOpts <> ")"
         logInfoNS "ema" "==============================================="
-  liftIO $ warpRunSettings settings mport (runM . banner) app
+  liftIO $ warpRunSettings settings mport banner app
 
 -- Like Warp.runSettings but takes *optional* port. When no port is set, a
 -- free (random) port is used.

--- a/ema/src/Ema/Server/Common.hs
+++ b/ema/src/Ema/Server/Common.hs
@@ -32,27 +32,23 @@ renderCatchingErrors ::
   m (Asset LByteString)
 renderCatchingErrors m r =
   catch (siteOutput (fromPrism_ $ routePrism m) m r) $ \(err :: SomeException) -> do
-    -- Log the error first.
-    logErrorNS "App" $ show @Text err
-    pure
-      $ AssetGenerated Html
-        . mkHtmlErrorMsg
-      $ show @Text err
+    let errMsg = show @Text err
+    logErrorNS "App" errMsg
+    pure $ AssetGenerated Html $ mkHtmlErrorMsg errMsg
 
 -- Decode an URL path into a route
 --
 -- This function is used only in live server. If the route is not
--- isomoprhic, this returns a Left, with the mismatched encoding.
+-- isomorphic, this returns a Left, with the mismatched encoding.
 decodeUrlRoute ::
   forall r.
   (Eq r, Show r, IsRoute r) =>
   RouteModel r ->
   Text ->
   Either (BadRouteEncoding r) (Maybe r)
-decodeUrlRoute m (urlToFilePath -> s) = do
-  case checkRoutePrismGivenFilePath routePrism m s of
-    Left (r, log) -> Left $ BadRouteEncoding s r log
-    Right mr -> Right mr
+decodeUrlRoute m (urlToFilePath -> s) =
+  first (\(r, log) -> BadRouteEncoding s r log) $
+    checkRoutePrismGivenFilePath routePrism m s
 
 -- | A basic error response for displaying in the browser
 emaErrorHtmlResponse :: Text -> LByteString
@@ -80,7 +76,7 @@ badRouteEncodingMsg BadRouteEncoding {..} =
       <> toText _bre_urlFilePath
       <> "' decodes to route '"
       <> show _bre_decodedRoute
-      <> "', but it is not isomporphic on any of the allowed candidates: \n\n"
+      <> "', but it is not isomorphic on any of the allowed candidates: \n\n"
       <> T.intercalate
         "\n\n"
         ( _bre_checkLog <&> \(candidate, log) ->

--- a/ema/src/Ema/Server/HTTP.hs
+++ b/ema/src/Ema/Server/HTTP.hs
@@ -5,7 +5,6 @@ module Ema.Server.HTTP where
 import Control.Monad.Logger
 import Data.LVar (LVar)
 import Data.LVar qualified as LVar
-import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Ema.Asset (
   Asset (AssetGenerated, AssetStatic),

--- a/ema/src/Ema/Server/WebSocket.hs
+++ b/ema/src/Ema/Server/WebSocket.hs
@@ -43,15 +43,15 @@ wsApp logger model emaWsHandler pendingConn = do
             Right Nothing ->
               liftIO $ WS.sendTextData conn $ emaErrorHtmlResponse decodeRouteNothingMsg
             Right (Just r) -> do
+              let redirectTo = "REDIRECT " <> toText (review (fromPrism_ $ routePrism s) r)
               renderCatchingErrors s r >>= \case
                 AssetGenerated Html html ->
                   liftIO $ WS.sendTextData conn $ html <> toLazy wsClientHtml
-                -- HACK: We expect the websocket client should check for REDIRECT prefix.
-                -- Not bothering with JSON response to avoid having to JSON parse every HTML dump.
-                AssetStatic _staticPath ->
-                  liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism s) r)
-                AssetGenerated Other _s ->
-                  liftIO $ WS.sendTextData conn $ "REDIRECT " <> toText (review (fromPrism_ $ routePrism s) r)
+                -- Non-HTML assets: tell the client to navigate via HTTP instead.
+                AssetStatic _ ->
+                  liftIO $ WS.sendTextData conn redirectTo
+                AssetGenerated Other _ ->
+                  liftIO $ WS.sendTextData conn redirectTo
               log LevelDebug $ " ~~> " <> show r
         -- @mWatchingRoute@ is the route currently being watched.
         loop mWatchingRoute = do


### PR DESCRIPTION
## Summary

Code elegance pass across the codebase, generated using the [`/elegance` command](https://github.com/srid/nixos-config/blob/master/AI/commands/elegance.md).

- Extract duplicated lock-and-update pattern in `Dynamic.hs` into `lockedUpdate`/`keepAlive` helpers
- Unify duplicate `FromMaybe` type family (remove from `Generic.hs`, export from `Symbol.hs`)
- Simplify `decodeUrlRoute` using `first` over `Either` instead of manual case matching
- Replace `if-then-else` with `when`/`unless`/`unlessM` where clearer
- Remove dead commented-out logging code in `Prism/Check.hs`
- Extract duplicated `REDIRECT` message in `WebSocket.hs`
- Clean up redundant imports, parens, and intermediate bindings
- Fix typos: `isomoprhic`, `isomporphic`, `tyupe`
- Rewrite `FromJSON UrlStrategy` with explicit `case` matching and proper error message

## Test plan

- [x] `nix run github:juspay/vira -- ci -b` passes