### PR TITLE
CLI: RunArgs as a record, expose runArgsParser

### DIFF
--- a/docs/topics/cli.md
+++ b/docs/topics/cli.md
@@ -3,16 +3,45 @@ order: 4
 ---
 # CLI
 
-Ema apps have a basic CLI argument structure that you can invoke in two possible ways:
+Every Ema site built with `Ema.runSite` exposes a small CLI out of the box. It picks one of two subcommands and a handful of flags, hands the result to your [[site]]'s `siteInput`, and does the right thing.
 
-1. `run` subcommand (or, no subcommand specified): Run the [[live-server]]. 
-    - A random port is used unless you specify one explicitly (`--port`)
-    - Pass `--no-ws` if you want to disable the "live" aspect of the server.
-2. `gen` subcommand: Generate the static site, instead of starting up the [[live-server]]
+## Subcommands
 
-The subcommand is passed as the `Ema.CLI.Action` type to your `siteInput` function in [[site]]. 
+- **`run`** — start the [[live-server]]. Also the default when no subcommand is given.
+- **`gen DEST`** — do a one-shot static build into `DEST` and exit.
 
-You can also use `runEmaWith` if you are manually handling the CLI arguments yourself and delegating to ema using `Ema.CLI` wherever appropriate.
+## Flags
+
+Under `run`:
+
+- `--host HOST` — interface to bind to. Defaults to `127.0.0.1`.
+- `--port PORT` — TCP port. If omitted, a random free port is chosen and printed at startup.
+- `--no-ws` — disable the websocket that powers hot-reload. The server still serves HTML, it just won't push updates.
+
+Top-level:
+
+- `-v`, `--verbose` — drop the log level from `Info` to `Debug`.
+
+## How the CLI reaches your code
+
+`Ema.runSite` parses `argv` into an `Ema.CLI.Cli` and routes the contained `Ema.CLI.Action` to your site: `Generate dest` triggers a static build, `Run RunArgs{..}` starts the live server. Your `EmaSite` instance receives the `Action` via `siteInput`, so you can condition behavior on whether Ema is generating or live-serving — e.g. skipping expensive watchers during a one-shot build.
+
+## Handing Ema a pre-built `Cli`
+
+If you want to control CLI parsing yourself — adding custom subcommands, re-ordering flags, or embedding Ema inside a larger tool — use `runSiteWith` instead of `runSite` and pass a `SiteConfig` carrying your own `Ema.CLI.Cli` value:
+
+```haskell
+import Ema qualified
+import Ema.CLI qualified
+
+main :: IO ()
+main = do
+  cli <- myCustomParser                       -- your own optparse-applicative
+  let cfg = Ema.SiteConfig cli def
+  void $ Ema.runSiteWith @MyRoute cfg mySiteArg
+```
+
+This is the escape hatch when the stock `Ema.CLI.cliParser` doesn't fit your UX.
 
 ## Composing custom flags under `run`
 

--- a/docs/topics/cli.md
+++ b/docs/topics/cli.md
@@ -13,3 +13,29 @@ Ema apps have a basic CLI argument structure that you can invoke in two possible
 The subcommand is passed as the `Ema.CLI.Action` type to your `siteInput` function in [[site]]. 
 
 You can also use `runEmaWith` if you are manually handling the CLI arguments yourself and delegating to ema using `Ema.CLI` wherever appropriate.
+
+## Composing custom flags under `run`
+
+`Ema.CLI.runArgsParser :: Parser RunArgs` is exported so downstream applications can splice Ema's `--host` / `--port` / `--no-ws` parser into their own `run` subcommand alongside custom flags. Prefer this over rebuilding `hostParser`/`portParser`/`noWebSocketParser` by hand — if Ema later grows a new run-mode field, the composed parser picks it up automatically.
+
+```haskell
+import Ema.CLI qualified
+import Options.Applicative
+
+data RunCmd = RunCmd
+  { runEmaArgs :: Ema.CLI.RunArgs
+  , runMyFlag  :: Maybe Int
+  }
+
+runCmdParser :: Parser RunCmd
+runCmdParser = RunCmd
+  <$> Ema.CLI.runArgsParser
+  <*> optional (option auto (long "my-flag" <> metavar "N"))
+
+-- When it's time to hand control to Ema, project RunCmd back into Ema.CLI.Cli:
+toEmaCli :: RunCmd -> Ema.CLI.Cli
+toEmaCli rc = Ema.CLI.Cli
+  { Ema.CLI.action  = Ema.CLI.Run (runEmaArgs rc)
+  , Ema.CLI.verbose = False
+  }
+```

--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.13.0.0 (Unreleased)
 
-- `Ema.CLI`
+- `Ema.CLI` ([#176](https://github.com/srid/ema/pull/176))
   - **Breaking**: `Action.Run` now carries a named record `RunArgs` instead of a bare `(Host, Maybe Port, NoWebSocket)` tuple. Migration: replace `Run (h, p, ws)` with `Run RunArgs { host = h, port = p, noWebSocket = ws }`.
   - New export `runArgsParser :: Parser RunArgs`. Downstream applications can compose it inside their own `run` subcommand to add custom flags without reconstructing Ema's host/port/no-ws parsers by hand.
 

--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for ema
 
+## 0.13.0.0 (Unreleased)
+
+- `Ema.CLI`
+  - **Breaking**: `Action.Run` now carries a named record `RunArgs` instead of a bare `(Host, Maybe Port, NoWebSocket)` tuple. Migration: replace `Run (h, p, ws)` with `Run RunArgs { host = h, port = p, noWebSocket = ws }`.
+  - New export `runArgsParser :: Parser RunArgs`. Downstream applications can compose it inside their own `run` subcommand to add custom flags without reconstructing Ema's host/port/no-ws parsers by hand.
+
 ## 0.12.0.0 (2025-07-22)
 
 - Relax `base` constraint forever

--- a/ema/ema.cabal
+++ b/ema/ema.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               ema
-version:            0.12.0.0
+version:            0.13.0.0
 license:            AGPL-3.0-only
 copyright:          2021 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/ema/src/Ema/App.hs
+++ b/ema/src/Ema/App.hs
@@ -85,7 +85,10 @@ runSiteWith cfg siteArg = do
       CLI.Generate dest -> do
         fs <- generateSiteFromModel @r dest model0
         pure (model0, (dest, fs))
-      CLI.Run (host, mport, CLI.unNoWebSocket -> noWebSocket) -> do
+      CLI.Run runArgs -> do
+        let host = CLI.host runArgs
+            mport = CLI.port runArgs
+            noWebSocket = CLI.unNoWebSocket (CLI.noWebSocket runArgs)
         model <- LVar.empty
         LVar.set model model0
         logger <- askLoggerIO

--- a/ema/src/Ema/CLI.hs
+++ b/ema/src/Ema/CLI.hs
@@ -20,13 +20,24 @@ newtype Host = Host {unHost :: Text}
 instance Default Host where
   def = "127.0.0.1"
 
+-- | Arguments that belong to the live-server ('Run') subcommand.
+data RunArgs = RunArgs
+  { host :: Host
+  , port :: Maybe Port
+  , noWebSocket :: NoWebSocket
+  }
+  deriving stock (Eq, Show, Generic)
+
+instance Default RunArgs where
+  def = RunArgs {host = def, port = Nothing, noWebSocket = def}
+
 -- | CLI subcommand
 data Action
   = -- | Generate static files at the given output directory, returning the list
     -- of generated files.
     Generate FilePath
   | -- | Run the live server
-    Run (Host, Maybe Port, NoWebSocket)
+    Run RunArgs
   deriving stock (Eq, Show, Generic)
 
 -- | Whether to disable websocket-based refresh and page loads.
@@ -59,18 +70,25 @@ cliParser = do
   action <-
     hsubparser
       ( command "gen" (info generate (progDesc "Generate static site"))
-          <> command "run" (info run (progDesc "Run the live server"))
+          <> command "run" (info (Run <$> runArgsParser) (progDesc "Run the live server"))
       )
       <|> pure (Run def)
   verbose <- switch (long "verbose" <> short 'v' <> help "Enable verbose logging")
   pure Cli {..}
   where
-    run :: Parser Action
-    run =
-      fmap Run $ (,,) <$> hostParser <*> optional portParser <*> noWebSocketParser
     generate :: Parser Action
     generate =
       Generate <$> argument str (metavar "DEST")
+
+{- | Parser for the live-server subcommand's arguments.
+
+Exposed so downstream applications can compose @--host@, @--port@, and
+@--no-ws@ into their own @run@ subcommand alongside custom flags,
+without having to reconstruct the parser by hand. If Ema adds a new
+field to 'RunArgs', downstream composers pick it up automatically.
+-}
+runArgsParser :: Parser RunArgs
+runArgsParser = RunArgs <$> hostParser <*> optional portParser <*> noWebSocketParser
 
 hostParser :: Parser Host
 hostParser =


### PR DESCRIPTION
**`Action.Run` now carries a named `RunArgs` record instead of a positional 3-tuple**, and `runArgsParser` is exported from `Ema.CLI`. The motivation is compositional CLIs: a downstream app (Emanote in this case) wants to add its own flag under `run` — e.g. `--mcp-port` for an in-process MCP server — alongside Ema's `--host` / `--port` / `--no-ws`. With the record + exposed parser, downstream can splice `runArgsParser` into its own subcommand tree, and any future field Ema adds to `RunArgs` flows through automatically.

The record also just reads better at pattern-match sites. *The tuple form had `CLI.Run (host, mport, CLI.unNoWebSocket -> noWebSocket)` — three positional binds plus a view pattern to unwrap the newtype. The record form spells each field out by name, which matters as `RunArgs` grows past three fields.*

> **Breaking:** any existing `Run (h, p, ws)` pattern must migrate to `Run RunArgs { host = h, port = p, noWebSocket = ws }` (or record-wildcard / positional equivalent). The only internal call site — `Ema.App.runSiteWith` — is updated in this PR. Version bumped to 0.13.0.0.

### Try it locally

```sh
nix build github:srid/ema/feat/run-args-record#ema
```

Downstream usage example (what Emanote will do next):

```haskell
data RunCmd = RunCmd
  { runEmaArgs :: Ema.CLI.RunArgs
  , runMcpPort :: Maybe Int
  }

runCmdParser :: Parser RunCmd
runCmdParser = RunCmd <$> Ema.CLI.runArgsParser <*> optional mcpPortOption
```