### PR TITLE
Add Ema.Dynamic.currentValue for out-of-band reads

### DIFF
--- a/docs/guide/model/dynamic.md
+++ b/docs/guide/model/dynamic.md
@@ -24,3 +24,24 @@ It is a pair of values: the initial value, and a function that knows how to upda
 The [[site]]'s `siteInput` method returns a `Dynamic` of [[model]], which represents all the data required to render a site. If you do not want [[hot-reload]], you may return a `pure` value.
 
 The use of a time-varying `Dynamic` is what enables [[hot-reload]]. See [here](https://github.com/fpindia/fpindia-site/pull/24/files) for an example of making a model time-varying. Checkout [[unionmount]] to produce a `Dynamic` of a model that updates based on the filesystem tree.
+
+## Reading the current value from outside
+
+`Dynamic` is push-only: its updater hands each new value to a callback the consumer supplies. That shape fits Ema's render loop, but not a second component that wants synchronous pull access to the latest value — e.g. an HTTP handler running alongside `runSiteWith` that needs the current model per request.
+
+`Ema.Dynamic.currentValue` tees a `Dynamic` for that case:
+
+```haskell
+currentValue :: MonadIO m => Dynamic m a -> m (IO a, Dynamic m a)
+```
+
+It returns a reader (`IO a`, yielding the most recently pushed value, or the initial value before any update) and a pass-through `Dynamic` that must be used in place of the input — the pass-through's updater is wired to feed the reader on each update.
+
+```haskell
+(readModel, dyn') <- currentValue dyn
+race_
+  (runSiteWith cfg arg dyn')          -- consumes dyn'
+  (serve $ \_req -> readModel)        -- reads the live model per request
+```
+
+Only one producer runs — the pass-through intercepts the send callback, it does not duplicate the underlying updater.

--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `Ema.CLI` ([#176](https://github.com/srid/ema/pull/176))
   - **Breaking**: `Action.Run` now carries a named record `RunArgs` instead of a bare `(Host, Maybe Port, NoWebSocket)` tuple. Migration: replace `Run (h, p, ws)` with `Run RunArgs { host = h, port = p, noWebSocket = ws }`.
   - New export `runArgsParser :: Parser RunArgs`. Downstream applications can compose it inside their own `run` subcommand to add custom flags without reconstructing Ema's host/port/no-ws parsers by hand.
-- `Ema.Dynamic`: new export `currentValue :: MonadIO m => Dynamic m a -> m (IO a, Dynamic m a)`. Tees a Dynamic so its latest value is readable synchronously from outside the consumer — useful when a second component (e.g. an HTTP handler) runs alongside a render loop and needs pull access to the current model. The returned Dynamic must be used in place of the input.
+- `Ema.Dynamic`: new export `currentValue` ([#177](https://github.com/srid/ema/pull/177)), a pull-side tee for consumers that need synchronous access to the current value.
 
 ## 0.12.0.0 (2025-07-22)
 

--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `Ema.CLI` ([#176](https://github.com/srid/ema/pull/176))
   - **Breaking**: `Action.Run` now carries a named record `RunArgs` instead of a bare `(Host, Maybe Port, NoWebSocket)` tuple. Migration: replace `Run (h, p, ws)` with `Run RunArgs { host = h, port = p, noWebSocket = ws }`.
   - New export `runArgsParser :: Parser RunArgs`. Downstream applications can compose it inside their own `run` subcommand to add custom flags without reconstructing Ema's host/port/no-ws parsers by hand.
+- `Ema.Dynamic`: new export `currentValue :: MonadIO m => Dynamic m a -> m (IO a, Dynamic m a)`. Tees a Dynamic so its latest value is readable synchronously from outside the consumer — useful when a second component (e.g. an HTTP handler) runs alongside a render loop and needs pull access to the current model. The returned Dynamic must be used in place of the input.
 
 ## 0.12.0.0 (2025-07-22)
 

--- a/ema/src/Ema/Dynamic.hs
+++ b/ema/src/Ema/Dynamic.hs
@@ -1,5 +1,6 @@
 module Ema.Dynamic (
   Dynamic (Dynamic),
+  currentValue,
 ) where
 
 import Control.Monad.Logger (MonadLogger, logDebugNS)
@@ -27,6 +28,42 @@ instance Functor (Dynamic m) where
       ( f x0
       , \send -> xf $ send . f
       )
+
+{- | Tee a 'Dynamic' so its latest value is readable out-of-band.
+
+Returns @(reader, wrapped)@:
+
+* @reader :: IO a@ yields the most recently pushed value, or the initial
+  value before any update.
+* @wrapped@ is a pass-through 'Dynamic' that must be used in place of the
+  input. Its updater calls the input's updater and additionally stores
+  each value for the reader.
+
+'Dynamic' is push-only: the updater takes a send callback and runs
+forever, producing values via that callback. That shape is a poor fit
+for consumers that need synchronous pull access to the current value
+(e.g. an HTTP handler running alongside a render loop). This helper
+bridges the gap without forking a second producer.
+
+Usage:
+
+> (readModel, dyn') <- currentValue dyn
+> race_
+>   (runSiteWith siteConfig siteArg dyn')   -- consumes dyn'
+>   (serveHttp $ \req -> readModel)         -- reads current model per request
+-}
+currentValue :: (MonadIO m) => Dynamic m a -> m (IO a, Dynamic m a)
+currentValue (Dynamic (x0, xf)) = do
+  ref <- liftIO $ newIORef x0
+  pure
+    ( readIORef ref
+    , Dynamic
+        ( x0
+        , \send -> xf $ \x -> do
+            liftIO $ writeIORef ref x
+            send x
+        )
+    )
 
 instance (MonadUnliftIO m, MonadLogger m) => Applicative (Dynamic m) where
   pure x = Dynamic (x, const pass)


### PR DESCRIPTION
**Dynamic is push-only**, but some consumers need pull. The updater shape `(a -> m ()) -> m ()` is perfect for a render loop that reacts to each new value, but a poor fit for a synchronous request handler — e.g. an HTTP server running alongside `runSiteWith` that wants to snapshot the current model per request. Before this PR, bridging push to pull meant hand-rolling an IORef tee outside Ema, as [srid/emanote#649 did in its `tapModel`](https://github.com/srid/emanote/pull/649). Moving the primitive into Ema lets downstream apps stop re-deriving the same 8-line pattern.

`currentValue` tees a Dynamic: it returns `(reader, wrapped)` where `reader :: IO a` yields the latest published value (or the initial before any update), and `wrapped :: Dynamic m a` is a pass-through that must be used in place of the input. The wrapped updater calls the original's updater and additionally stores each value into the IORef backing the reader. _No second producer thread, no FS-watcher duplication_ — there's still one updater running, we just intercept the send callback.

> **Non-breaking.** The Dynamic newtype is unchanged; `currentValue` is purely additive. Callers that don't need pull access ignore the new export.

### Try it locally

```sh
nix build github:srid/ema/feat/dynamic-current-value
```

Or see it in action once downstream lands: https://github.com/srid/emanote/pull/649