### PR TITLE
Factor runSiteWith into siteInput + runSiteWithInput

### DIFF
--- a/docs/guide/model/dynamic.md
+++ b/docs/guide/model/dynamic.md
@@ -35,18 +35,9 @@ The use of a time-varying `Dynamic` is what enables [[hot-reload]]. See [here](h
 currentValue :: MonadIO m => Dynamic m a -> m (IO a, Dynamic m a)
 ```
 
-It returns a reader (`IO a`, yielding the most recently pushed value, or the initial value before any update) and a pass-through `Dynamic` that must be used in place of the input — the pass-through's updater is wired to feed the reader on each update.
+It returns a reader (`IO a`, yielding the most recently pushed value, or the initial value before any update) and a pass-through `Dynamic` that must be used in place of the input — the pass-through's updater is wired to feed the reader on each update. Only one producer runs; the pass-through intercepts the send callback, it does not duplicate the underlying updater.
 
-```haskell
-(readModel, dyn') <- currentValue dyn
-race_
-  (runSiteWith cfg arg dyn')          -- consumes dyn'
-  (serve $ \_req -> readModel)        -- reads the live model per request
-```
-
-Only one producer runs — the pass-through intercepts the send callback, it does not duplicate the underlying updater.
-
-`Ema.App.runSiteWithInput` takes a pre-built `Dynamic` instead of calling `siteInput` for you, which is what makes the `race_ (…) (runSiteWith …)` shape workable:
+To compose this with Ema's own render loop, use `Ema.App.runSiteWithInput`, which takes a pre-built `Dynamic` instead of calling `siteInput` for you:
 
 ```haskell
 flip runLoggerLoggingT logger $ do

--- a/docs/guide/model/dynamic.md
+++ b/docs/guide/model/dynamic.md
@@ -50,12 +50,11 @@ Only one producer runs — the pass-through intercepts the send callback, it doe
 
 ```haskell
 flip runLoggerLoggingT logger $ do
-  rawDyn          <- siteInput @r action arg       -- your EmaSite.siteInput runs
+  rawDyn            <- siteInput @r action arg     -- your EmaSite.siteInput runs
   (readModel, dyn') <- currentValue rawDyn         -- tee for out-of-band reads
-  liftIO $ publishReader readModel                 -- hand the reader to an observer
-  withRunInIO $ \runIO -> race_
+  race_
     (myObserver readModel)                          -- whatever needs the live model
-    (runIO $ runSiteWithInput cfg dyn')            -- Ema drives the wrapped Dynamic
+    (runSiteWithInput cfg dyn')                     -- Ema drives the wrapped Dynamic
 ```
 
-`runSiteWith` itself becomes a one-liner wrapper around `siteInput` + `runSiteWithInput`, so callers that don't need the tee are unaffected.
+`UnliftIO.Async.race_` handles both branches in `m` directly — no `withRunInIO`/`liftIO` dance needed. `runSiteWith` itself becomes a one-liner wrapper around `siteInput` + `runSiteWithInput`, so callers that don't need the tee are unaffected.

--- a/docs/guide/model/dynamic.md
+++ b/docs/guide/model/dynamic.md
@@ -45,3 +45,17 @@ race_
 ```
 
 Only one producer runs — the pass-through intercepts the send callback, it does not duplicate the underlying updater.
+
+`Ema.App.runSiteWithInput` takes a pre-built `Dynamic` instead of calling `siteInput` for you, which is what makes the `race_ (…) (runSiteWith …)` shape workable:
+
+```haskell
+flip runLoggerLoggingT logger $ do
+  rawDyn          <- siteInput @r action arg       -- your EmaSite.siteInput runs
+  (readModel, dyn') <- currentValue rawDyn         -- tee for out-of-band reads
+  liftIO $ publishReader readModel                 -- hand the reader to an observer
+  withRunInIO $ \runIO -> race_
+    (myObserver readModel)                          -- whatever needs the live model
+    (runIO $ runSiteWithInput cfg dyn')            -- Ema drives the wrapped Dynamic
+```
+
+`runSiteWith` itself becomes a one-liner wrapper around `siteInput` + `runSiteWithInput`, so callers that don't need the tee are unaffected.

--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -6,7 +6,7 @@
   - **Breaking**: `Action.Run` now carries a named record `RunArgs` instead of a bare `(Host, Maybe Port, NoWebSocket)` tuple. Migration: replace `Run (h, p, ws)` with `Run RunArgs { host = h, port = p, noWebSocket = ws }`.
   - New export `runArgsParser :: Parser RunArgs`. Downstream applications can compose it inside their own `run` subcommand to add custom flags without reconstructing Ema's host/port/no-ws parsers by hand.
 - `Ema.Dynamic`: new export `currentValue` ([#177](https://github.com/srid/ema/pull/177)), a pull-side tee for consumers that need synchronous access to the current value.
-- `Ema.App`: new export `runSiteWithInput` — `runSiteWith` factored into `siteInput` + Dynamic consumption, letting callers insert logic between the two (e.g. `currentValue`-tee for out-of-band consumers).
+- `Ema.App`: new export `runSiteWithInput` ([#179](https://github.com/srid/ema/pull/179)) — `runSiteWith` factored into `siteInput` + Dynamic consumption, letting callers insert logic between the two (e.g. `currentValue`-tee for out-of-band consumers).
 
 ## 0.12.0.0 (2025-07-22)
 

--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -6,6 +6,7 @@
   - **Breaking**: `Action.Run` now carries a named record `RunArgs` instead of a bare `(Host, Maybe Port, NoWebSocket)` tuple. Migration: replace `Run (h, p, ws)` with `Run RunArgs { host = h, port = p, noWebSocket = ws }`.
   - New export `runArgsParser :: Parser RunArgs`. Downstream applications can compose it inside their own `run` subcommand to add custom flags without reconstructing Ema's host/port/no-ws parsers by hand.
 - `Ema.Dynamic`: new export `currentValue` ([#177](https://github.com/srid/ema/pull/177)), a pull-side tee for consumers that need synchronous access to the current value.
+- `Ema.App`: new export `runSiteWithInput` — `runSiteWith` factored into `siteInput` + Dynamic consumption, letting callers insert logic between the two (e.g. `currentValue`-tee for out-of-band consumers).
 
 ## 0.12.0.0 (2025-07-22)
 

--- a/ema/ema.cabal
+++ b/ema/ema.cabal
@@ -78,7 +78,6 @@ library
   -- other-extensions:
   build-depends:
     , aeson
-    , async
     , base                   >=4.13.0.0 && <4.99
     , data-default
     , directory

--- a/ema/src/Ema/App.hs
+++ b/ema/src/Ema/App.hs
@@ -5,11 +5,11 @@ module Ema.App (
   runSite,
   runSite_,
   runSiteWith,
+  runSiteWithInput,
 ) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (race_)
-import Control.Monad.Logger (LoggingT (runLoggingT), MonadLoggerIO (askLoggerIO), logInfoNS, logWarnNS)
+import Control.Monad.Logger (MonadLoggerIO, logInfoNS, logWarnNS)
 import Control.Monad.Logger.Extras (runLoggerLoggingT)
 import Data.Default (Default, def)
 import Data.LVar qualified as LVar
@@ -21,6 +21,8 @@ import Ema.Route.Class (IsRoute (RouteModel))
 import Ema.Server qualified as Server
 import Ema.Site (EmaSite (SiteArg, siteInput), EmaStaticSite)
 import System.Directory (getCurrentDirectory)
+import UnliftIO (MonadUnliftIO)
+import UnliftIO.Async (race_)
 
 data SiteConfig r = SiteConfig
   { siteConfigCli :: CLI.Cli
@@ -75,34 +77,63 @@ runSiteWith ::
       (FilePath, [FilePath])
     )
 runSiteWith cfg siteArg = do
+  let cli = siteConfigCli cfg
+  flip runLoggerLoggingT (getLogger cli) $ do
+    dyn <- siteInput @r (CLI.action cli) siteArg
+    runSiteWithInput cfg dyn
+
+{- | Like 'runSiteWith' but accepts a pre-built 'Dynamic' instead of
+calling 'siteInput' internally.
+
+Useful when you need to insert logic between the 'Dynamic''s construction
+and its consumption — for example, to 'Ema.Dynamic.currentValue'-tee it
+for an out-of-band consumer (HTTP API, metrics, test harness) or to
+'Applicative'-compose it with another source.
+
+'siteInput' still defines /how/ to build the 'Dynamic'; the caller just
+invokes it explicitly, threads the result through whatever combinators
+they need, and hands it here.
+
+> do
+>   dyn <- siteInput @r action arg              -- user's siteInput runs
+>   (readModel, wrapped) <- currentValue dyn    -- tee for out-of-band reads
+>   race_ (myObserver readModel)
+>         (runSiteWithInput cfg wrapped)
+-}
+runSiteWithInput ::
+  forall r m.
+  (MonadUnliftIO m, MonadLoggerIO m, MonadFail m, Show r, Eq r, EmaStaticSite r) =>
+  SiteConfig r ->
+  Dynamic m (RouteModel r) ->
+  m
+    ( -- The initial model value.
+      RouteModel r
+    , -- Out path, and the list of statically generated files
+      (FilePath, [FilePath])
+    )
+runSiteWithInput cfg (Dynamic (model0 :: RouteModel r, cont)) = do
   let opts = siteConfigWebSocketOptions cfg
       cli = siteConfigCli cfg
-  flip runLoggerLoggingT (getLogger cli) $ do
-    cwd <- liftIO getCurrentDirectory
-    logInfoNS "ema" $ "Launching Ema under: " <> toText cwd
-    Dynamic (model0 :: RouteModel r, cont) <- siteInput @r (CLI.action cli) siteArg
-    case CLI.action cli of
-      CLI.Generate dest -> do
-        fs <- generateSiteFromModel @r dest model0
-        pure (model0, (dest, fs))
-      CLI.Run runArgs -> do
-        let host = CLI.host runArgs
-            mport = CLI.port runArgs
-            noWebSocket = CLI.unNoWebSocket (CLI.noWebSocket runArgs)
-        model <- LVar.empty
-        LVar.set model model0
-        logger <- askLoggerIO
-        let mWsOpts = if noWebSocket then Nothing else Just opts
-        liftIO $
-          race_
-            ( flip runLoggingT logger $ do
-                cont $ LVar.set model
-                logWarnNS "ema" "modelPatcher exited; no more model updates!"
-                -- We want to keep this thread alive, so that the server thread
-                -- doesn't exit.
-                liftIO $ threadDelay maxBound
-            )
-            ( flip runLoggingT logger $ do
-                Server.runServerWithWebSocketHotReload @r mWsOpts host mport model
-            )
-        CLI.crash "ema" "Live server unexpectedly stopped"
+  cwd <- liftIO getCurrentDirectory
+  logInfoNS "ema" $ "Launching Ema under: " <> toText cwd
+  case CLI.action cli of
+    CLI.Generate dest -> do
+      fs <- generateSiteFromModel @r dest model0
+      pure (model0, (dest, fs))
+    CLI.Run runArgs -> do
+      let host = CLI.host runArgs
+          mport = CLI.port runArgs
+          noWebSocket = CLI.unNoWebSocket (CLI.noWebSocket runArgs)
+          mWsOpts = if noWebSocket then Nothing else Just opts
+      model <- LVar.empty
+      LVar.set model model0
+      race_
+        ( do
+            cont $ LVar.set model
+            logWarnNS "ema" "modelPatcher exited; no more model updates!"
+            -- We want to keep this thread alive, so that the server thread
+            -- doesn't exit.
+            liftIO $ threadDelay maxBound
+        )
+        (Server.runServerWithWebSocketHotReload @r mWsOpts host mport model)
+      CLI.crash "ema" "Live server unexpectedly stopped"

--- a/ema/src/Ema/App.hs
+++ b/ema/src/Ema/App.hs
@@ -102,7 +102,9 @@ they need, and hands it here.
 -}
 runSiteWithInput ::
   forall r m.
-  (MonadUnliftIO m, MonadLoggerIO m, MonadFail m, Show r, Eq r, EmaStaticSite r) =>
+  -- MonadUnliftIO for the race_ between updater and server; MonadLoggerIO for
+  -- Ema's own startup / patch / error logs.
+  (MonadUnliftIO m, MonadLoggerIO m, Show r, Eq r, EmaStaticSite r) =>
   SiteConfig r ->
   Dynamic m (RouteModel r) ->
   m

--- a/ema/src/Ema/CLI.hs
+++ b/ema/src/Ema/CLI.hs
@@ -12,6 +12,8 @@ import Control.Monad.Logger.Extras (
 import Data.Default (Default (def))
 import Network.Wai.Handler.Warp (Port)
 import Options.Applicative hiding (action)
+import System.IO.Error (userError)
+import UnliftIO.Exception (throwIO)
 
 -- | Host string to start the server on.
 newtype Host = Host {unHost :: Text}
@@ -131,7 +133,7 @@ getLogger cli =
 
  First log the message using Error level, and then exit using `fail`.
 -}
-crash :: (MonadLoggerIO m, MonadFail m) => LogSource -> Text -> m a
+crash :: (MonadLoggerIO m) => LogSource -> Text -> m a
 crash source msg = do
   logErrorNS source msg
-  fail $ toString msg
+  liftIO $ throwIO $ userError $ toString msg

--- a/ema/src/Ema/Generate.hs
+++ b/ema/src/Ema/Generate.hs
@@ -37,7 +37,7 @@ log = logWithoutLoc "ema.generate"
 -}
 generateSiteFromModel ::
   forall r m.
-  (MonadIO m, MonadLoggerIO m, MonadFail m, Eq r, Show r, IsRoute r, EmaStaticSite r) =>
+  (MonadIO m, MonadLoggerIO m, Eq r, Show r, IsRoute r, EmaStaticSite r) =>
   -- | Target directory to write files to. Must exist.
   FilePath ->
   -- | The model data used to generate assets.


### PR DESCRIPTION
**`runSiteWith` now composes out of two steps** — `siteInput` (build the `Dynamic`) and `runSiteWithInput` (consume it). The same class of problems that motivated `currentValue` (#177) — teeing the `Dynamic` for an out-of-band consumer — needs a seam between those two steps. Before this PR, `runSiteWith` sealed them together; the only escape was plumbing a callback through the user's `SiteArg`, which either conflated config with transport wiring or (worse) bypassed the user's `siteInput` entirely.

_The user's `siteInput` still runs._ Callers that need the tee just invoke `siteInput` themselves, compose (`currentValue`, `<*>`, whatever), and pass the result to `runSiteWithInput`. Callers that don't need it keep using `runSiteWith` exactly as before — its body is now a two-liner:

```haskell
runSiteWith cfg arg = flip runLoggerLoggingT (getLogger …) $ do
  dyn <- siteInput @r (CLI.action cli) arg
  runSiteWithInput cfg dyn
```

`runSiteWithInput` is polymorphic in `m` (`MonadUnliftIO m, MonadLoggerIO m, MonadFail m`), which also lets the live-server race stay in one logger context — `UnliftIO.Async.race_` replaces `Control.Concurrent.Async.race_`, and both branches run in `m` directly. Net: the existing `liftIO $ race_` / `runLoggingT logger` scaffolding collapses, and `async` drops out of the direct deps (it's still pulled in transitively via `unliftio`).

> Fully additive. `runSite`, `runSite_`, `runSiteWith` are unchanged in signature and behaviour. `runSiteWithInput` is a new export.

Motivated by [srid/emanote#649](https://github.com/srid/emanote/pull/649)'s MCP server: with this PR, emanote drops its `tapModel` helper, the `_emanoteConfigOnLiveModel` callback field, and the publish-through-config plumbing entirely — MCP and Ema compose via `race_` at the call site.

### Try it locally

```sh
nix build github:srid/ema/feat/run-site-with-input
```