### PR TITLE
ema-shim: expose window.ema.ready promise

### DIFF
--- a/ema/CHANGELOG.md
+++ b/ema/CHANGELOG.md
@@ -7,6 +7,7 @@
   - New export `runArgsParser :: Parser RunArgs`. Downstream applications can compose it inside their own `run` subcommand to add custom flags without reconstructing Ema's host/port/no-ws parsers by hand.
 - `Ema.Dynamic`: new export `currentValue` ([#177](https://github.com/srid/ema/pull/177)), a pull-side tee for consumers that need synchronous access to the current value.
 - `Ema.App`: new export `runSiteWithInput` ([#179](https://github.com/srid/ema/pull/179)) — `runSiteWith` factored into `siteInput` + Dynamic consumption, letting callers insert logic between the two (e.g. `currentValue`-tee for out-of-band consumers).
+- `ema-shim.js`: expose `window.ema.ready`, a Promise that resolves on first WS handshake. Lets external scripts (test harnesses, IDE integrations) call `window.ema.switchRoute` without racing the open. Reconnects don't reset it — it's a one-shot \"client is past first handshake\" gate.
 
 ## 0.12.0.0 (2025-07-22)
 

--- a/ema/www/ema-shim.js
+++ b/ema/www/ema-shim.js
@@ -60,6 +60,17 @@ const basePath = baseHref ? new URL(baseHref).pathname : "/";
 const wsProto = window.location.protocol === "https:" ? "wss://" : "ws://";
 const wsUrl = wsProto + window.location.host + basePath;
 
+// `window.ema.ready` resolves the first time the WS opens. Reconnects
+// don't reset it — it's a one-shot \"client is past first handshake\"
+// gate, intended for callers (test harnesses, external scripts) that
+// want to invoke `window.ema.switchRoute` without racing the WS open.
+// Set up at module load so listeners attached before init() runs still
+// hook the same promise.
+let _resolveReady;
+const _readyPromise = new Promise((resolve) => {
+  _resolveReady = resolve;
+});
+
 // WebSocket logic: watching for server changes & route switching
 function init(reconnecting) {
   // The route current DOM is displaying
@@ -146,6 +157,7 @@ function init(reconnecting) {
       reloadScripts(document.documentElement);
     }
     watchCurrentRoute();
+    _resolveReady();
   };
 
   ws.onclose = () => {
@@ -201,5 +213,6 @@ function init(reconnecting) {
   // API for user invocations
   window.ema = {
     switchRoute: switchRoute,
+    ready: _readyPromise,
   };
 }


### PR DESCRIPTION
**`window.ema.ready`** now resolves on first WebSocket handshake — a one-shot gate for external scripts that need to call `window.ema.switchRoute` (or any other WS-dependent API we add later) without racing the connection open. Reconnects don't reset it; it's a *first-open* signal, not a current-state flag.

Motivated by Emanote's e2e suite ([srid/emanote#667](https://github.com/srid/emanote/issues/667)), where a Playwright step needs to programmatically navigate via `switchRoute` to exercise the morph code path. The natural alternative — \`page.waitForTimeout\` — is flaky against cold-start emanote. Polling for `WebSocket.OPEN` requires exposing the `ws` instance, which is closure-scoped on purpose. A one-line Promise on the public API surface is the cheapest, broadest fix.

Tiny behavior addition; no breaking change. The existing `window.ema = { switchRoute }` shape gets one new field; nothing existing moves.